### PR TITLE
docs: Add Contributing, CoC, and edit README and package.json files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [community@orbitdb.org](mailto:community@orbitdb.org), which goes to all members of the @OrbitDB community team, or to [richardlitt@orbitdb.org](mailto:richardlitt@orbitdb.org), which goes only to [@RichardLitt](https://github.com/RichardLitt) or to [haadcode@orbitdb.org](mailto:haadcode@orbitdb.org), which goes only to [@haadcode](https://github.com/haadcode). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contribute
+
+Please contribute! Here are some things that would be great:
+
+- [Open an issue!](https://github.com/orbitdb/orbit-db-http-api/issues/new)
+- Open a pull request!
+- Say hi! :wave:
+
+Please note that we have a [Code of Conduct](CODE_OF_CONDUCT.md), and that all activity in the [@OrbitDB](https://github.com/orbitdb) organization falls under it. Read it before you contribute, as being part of this community means that you agree to abide by it. Thanks.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # OrbitDB HTTP API Server
 
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/orbitdb/Lobby)
+[![npm version](https://badge.fury.io/js/orbit-db-http-api.svg)](https://www.npmjs.com/package/orbit-db-http-api)
+[![node](https://img.shields.io/node/v/orbit-db-http-api.svg)](https://www.npmjs.com/package/orbit-db-http-api)
 
-> A HTTP API Server for the OrbitDB distributed peer-to-peer database.
+> An HTTP API Server for the OrbitDB distributed peer-to-peer database.
+
+**Table of Contents**
+
+- [Install](#install)
+- [Setup](#setup)
+- [API](#api)
+  - [GET /dbs](#get-dbs)
+  - [GET /db/:dbname](#get-dbdbname)
+  - [GET /db/:dbname/value](#get-dbdbnamevalue)
+  - [GET /db/:dbname/query](#get-dbdbnamequery)
+    - [Modulus Query](#modulus-query)
+    - [Range Query](#range-query)
+  - [GET /db/:dbname/:item](#get-dbdbnameitem)
+  - [POST /db/:dbname](#post-dbdbname)
+  - [GET /db/:dbname/iterator](#get-dbdbnameiterator)
+  - [GET /db/:dbname/all](#get-dbdbnameall)
 
 ## Install
 
@@ -252,7 +270,7 @@ curl -X GET http://localhost:3000/db/all
 ```
 
 ```json
-{"Key1":{"name":"Value1"},"Key2":{"name":"Value2"},"projects":"{["orbitdb","ipfs"]}}
+{"Key1":{"name":"Value1"},"Key2":{"name":"Value2"},"projects":"\{["orbitdb","ipfs"]}}
 ```
 
 ### POST|PUT /db/:dbname/add
@@ -341,3 +359,17 @@ curl -X DELETE http://localhost:3000/db/docstore/1
 ```json
 zdpuB39Yv1LV6CMYuNUgRi125utDpUoiP7PDsumjn1T4ASkzN
 ```
+
+## Contribute
+
+We would be happy to accept PRs! If you want to work on something, it'd be good to talk beforehand to make sure nobody else is working on it. You can reach us [on Gitter](https://gitter.im/orbitdb/Lobby), or in the [issues section](https://github.com/orbitdb/orbit-db-http-api/issues).
+
+We also have **regular community calls**, which we announce in the issues in [the @orbitdb welcome repository](https://github.com/orbitdb/welcome/issues). Join us!
+
+If you want to code but don't know where to start, check out the issues labelled ["help wanted"](https://github.com/orbitdb/orbit-db-http-api/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+sort%3Areactions-%2B1-desc).
+
+For specific guidelines for contributing to this repository, check out the [Contributing guide](CONTRIBUTING.md). For more on contributing to OrbitDB in general, take a look at the [@OrbitDB welcome repository](https://github.com/orbitdb/welcome). Please note that all interactions in [@OrbitDB](https://github.com/orbitdb) fall under our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+[MIT](LICENSE) © 2019 phillmac

--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
     "name": "orbit-db-http-api",
     "version": "0.1.0",
-    "description": "HTTP Api For OrbitDb",
+    "description": "An HTTP API Server for the OrbitDB distributed peer-to-peer database",
     "main": "src/cli.js",
+    "keywords": [
+      "orbitdb",
+      "orbit-db",
+      "http",
+      "api",
+      "server",
+      "peer-to-peer",
+      "database",
+      "db"
+    ],
     "scripts": {
       "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
This should fill out the default documentation for the OrbitDB org a bit more.