### PR TITLE
Updating dependencies and conventions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,407 +4,752 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@hapi/accept": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-3.2.4.tgz",
-      "integrity": "sha512-soThGB+QMgfxlh0Vzhzlf3ZOEOPk5biEwcOXhkF0Eedqx8VnhGiggL9UYHrIsOb1rUg3Be3K8kp0iDL2wbVSOQ==",
+    "@assemblyscript/loader": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
+      "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
+    },
+    "@ethersproject/abi": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+      "integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "@ethersproject/abstract-provider": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.4.tgz",
+      "integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/networks": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6"
+      }
+    },
+    "@ethersproject/abstract-signer": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.5.tgz",
+      "integrity": "sha512-nwSZKtCTKhJADlW42c+a//lWxQlnA7jYLTnabJ3YCfgGU6ic9jnT9nRDlAyT1U3kCMeqPL7fTcKbdWCVrM0xsw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3"
+      }
+    },
+    "@ethersproject/address": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+      "integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/rlp": "^5.0.3",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/base64": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.3.tgz",
+      "integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4"
+      }
+    },
+    "@ethersproject/basex": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.3.tgz",
+      "integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/properties": "^5.0.3"
+      }
+    },
+    "@ethersproject/bignumber": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+      "integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "bn.js": "^4.4.0"
+      }
+    },
+    "@ethersproject/bytes": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+      "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/constants": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+      "integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7"
+      }
+    },
+    "@ethersproject/contracts": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.4.tgz",
+      "integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
+      "requires": {
+        "@ethersproject/abi": "^5.0.5",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3"
+      }
+    },
+    "@ethersproject/hash": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.4.tgz",
+      "integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "@ethersproject/hdnode": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.4.tgz",
+      "integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/basex": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/pbkdf2": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/wordlists": "^5.0.4"
+      }
+    },
+    "@ethersproject/json-wallets": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.6.tgz",
+      "integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
+      "requires": {
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/pbkdf2": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "@ethersproject/keccak256": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+      "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "js-sha3": "0.5.7"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@ethersproject/logger": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+      "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w=="
+    },
+    "@ethersproject/networks": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.3.tgz",
+      "integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/pbkdf2": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.3.tgz",
+      "integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/sha2": "^5.0.3"
+      }
+    },
+    "@ethersproject/properties": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+      "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+      "requires": {
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/providers": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.9.tgz",
+      "integrity": "sha512-UtGrlJxekFNV7lriPOxQbnYminyiwTgjHMPX83pG7N/W/t+PekQK8V9rdlvMr2bRyGgafHml0ZZMaTV4FxiBYg==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/basex": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/networks": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/rlp": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/web": "^5.0.6",
+        "bech32": "1.1.4",
+        "ws": "7.2.3"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+          "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+        }
+      }
+    },
+    "@ethersproject/random": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.3.tgz",
+      "integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/rlp": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+      "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/sha2": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.3.tgz",
+      "integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "hash.js": "1.1.3"
+      },
+      "dependencies": {
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@ethersproject/signing-key": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+      "integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "elliptic": "6.5.3"
+      }
+    },
+    "@ethersproject/solidity": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.4.tgz",
+      "integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "@ethersproject/strings": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.4.tgz",
+      "integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+      "integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
+      "requires": {
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/rlp": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4"
+      }
+    },
+    "@ethersproject/units": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.4.tgz",
+      "integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5"
+      }
+    },
+    "@ethersproject/wallet": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.4.tgz",
+      "integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
+      "requires": {
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.4",
+        "@ethersproject/json-wallets": "^5.0.6",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/wordlists": "^5.0.4"
+      }
+    },
+    "@ethersproject/web": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.7.tgz",
+      "integrity": "sha512-BM8FdGrzdcULYaOIyMXDKvxv+qOwGne8FKpPxUrifZIWAWPrq/y+oBOZlzadIKsP3wvYbAcMN2CgOLO1E3yIfw==",
+      "requires": {
+        "@ethersproject/base64": "^5.0.3",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "@ethersproject/wordlists": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.4.tgz",
+      "integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
+      "requires": {
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/strings": "^5.0.4"
+      }
+    },
+    "@hapi/accept": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.1.tgz",
+      "integrity": "sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
     },
     "@hapi/ammo": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-3.1.2.tgz",
-      "integrity": "sha512-ej9OtFmiZv1qr45g1bxEZNGyaR4jRpyMxU6VhbxjaYThymvOwsyIsUKMZnP5Qw2tfYFuwqCJuIBHGpeIbdX9gQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/b64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-4.2.1.tgz",
-      "integrity": "sha512-zqHpQuH5CBMw6hADzKfU/IGNrxq1Q+/wTYV+OiZRQN9F3tMyk+9BUMeBvFRMamduuqL8iSp62QAnJ+7ATiYLWA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/boom": {
-      "version": "7.4.11",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-7.4.11.tgz",
-      "integrity": "sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bounce": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-1.3.2.tgz",
-      "integrity": "sha512-3bnb1AlcEByFZnpDIidxQyw1Gds81z/1rSqlx4bIEE+wUN0ATj0D49B5cE1wGocy90Rp/de4tv7GjsKd5RQeew==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "^8.3.1"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/bourne": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
     },
     "@hapi/call": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-5.1.3.tgz",
-      "integrity": "sha512-5DfWpMk7qZiYhvBhM5oUiT4GQ/O8a2rFR121/PdwA/eZ2C1EsuD547ZggMKAR5bZ+FtxOf0fdM20zzcXzq2mZA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/catbox": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-10.2.3.tgz",
-      "integrity": "sha512-kN9hXO4NYyOHW09CXiuj5qW1syc/0XeVOBsNNk0Tz89wWNQE5h21WF+VsfAw3uFR8swn/Wj3YEVBnWqo82m/JQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x",
-        "@hapi/podium": "3.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/catbox-memory": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-4.1.1.tgz",
-      "integrity": "sha512-T6Hdy8DExzG0jY7C8yYWZB4XHfc0v+p1EGkwxl2HoaPYAmW7I3E59M/IvmSVpis8RPcIoBp41ZpO2aZPBpM2Ww==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.0.tgz",
+      "integrity": "sha512-ByuxVJPHNaXwLzbBv4GdTr6ccpe1nG+AfYt+8ftDWEJY7EWBWzD+Klhy5oPTDGzU26pNUh1e7fcYI1ILZRxAXQ==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/content": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-4.1.1.tgz",
-      "integrity": "sha512-3TWvmwpVPxFSF3KBjKZ8yDqIKKZZIm7VurDSweYpXYENZrJH3C1hd1+qEQW9wQaUaI76pPBLGrXl6I3B7i3ipA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
       "requires": {
-        "@hapi/boom": "7.x.x"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/cryptiles": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-4.2.1.tgz",
-      "integrity": "sha512-XoqgKsHK0l/VpqPs+tr6j6vE+VQ3+2bkF2stvttmc7xAOf1oSAwHcJ0tlp/6MxMysktt1IEY0Csy3khKaP9/uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
       "requires": {
-        "@hapi/boom": "7.x.x"
+        "@hapi/boom": "9.x.x"
       }
     },
     "@hapi/file": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-1.0.0.tgz",
-      "integrity": "sha512-Bsfp/+1Gyf70eGtnIgmScvrH8sSypO3TcK3Zf0QdHnzn/ACnAkI6KLtGACmNRPEzzIy+W7aJX5E+1fc9GwIABQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
     "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
     },
     "@hapi/hapi": {
-      "version": "18.4.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-18.4.1.tgz",
-      "integrity": "sha512-9HjVGa0Z4Qv9jk9AVoUdJMQLA+KuZ+liKWyEEkVBx3e3H1F0JM6aGbPkY9jRfwsITBWGBU2iXazn65SFKSi/tg==",
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.0.0.tgz",
+      "integrity": "sha512-Wh0tIDFsl7nemU2JQYW4zZVr9XkpuZ1eM3yaX8tzaYdaYXon8QeB5NzrTNQY3R1/+fO7amQUrOoLLNPRwIZfgw==",
       "requires": {
-        "@hapi/accept": "^3.2.4",
-        "@hapi/ammo": "^3.1.2",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/call": "^5.1.3",
-        "@hapi/catbox": "10.x.x",
-        "@hapi/catbox-memory": "4.x.x",
-        "@hapi/heavy": "6.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "15.x.x",
-        "@hapi/mimos": "4.x.x",
-        "@hapi/podium": "3.x.x",
-        "@hapi/shot": "4.x.x",
-        "@hapi/somever": "2.x.x",
-        "@hapi/statehood": "6.x.x",
-        "@hapi/subtext": "^6.1.3",
-        "@hapi/teamwork": "3.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/call": "8.x.x",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "5.x.x",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/mimos": "5.x.x",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.1",
+        "@hapi/somever": "3.x.x",
+        "@hapi/statehood": "^7.0.3",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/topo": "5.x.x",
+        "@hapi/validate": "^1.1.0"
       }
     },
     "@hapi/heavy": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-6.2.2.tgz",
-      "integrity": "sha512-PY1dCCO6dsze7RlafIRhTaGeyTgVe49A/lSkxbhKGjQ7x46o/OFf7hLiRqTCDh3atcEKf6362EaB3+kTUbCsVA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
     },
     "@hapi/inert": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-5.2.2.tgz",
-      "integrity": "sha512-8IaGfAEF8SwZtpdaTq0G3aDPG35ZTfWKjnMNniG2N3kE+qioMsBuImIGxna8TNQ+sYMXYK78aqmvzbQHno8qSQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-6.0.2.tgz",
+      "integrity": "sha512-cq0a8jstkLW1+oJaw4jp52PZBEkVbX9d0YDy5aOs3rOKYSjpzs2nQBahnCHEMchOrOSUffLpE+IDoivYHcx8uA==",
       "requires": {
-        "@hapi/ammo": "3.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x",
-        "lru-cache": "4.1.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        },
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        }
+        "@hapi/ammo": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x",
+        "lru-cache": "5.x.x"
       }
     },
     "@hapi/iron": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-5.1.4.tgz",
-      "integrity": "sha512-+ElC+OCiwWLjlJBmm8ZEWjlfzTMQTdgPnU/TsoU5QsktspIWmWi9IU4kU83nH+X/SSya8TP8h8P11Wr5L7dkQQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x"
-      }
-    },
-    "@hapi/joi": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
-      "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/mimos": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-4.1.1.tgz",
-      "integrity": "sha512-CXoi/zfcTWfKYX756eEea8rXJRIb9sR4d7VwyAH9d3BkDyNgAesZxvqIdm55npQc6S9mU3FExinMAQVlIkz0eA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",
+      "integrity": "sha512-EVS6wJYeE73InTlPWt+2e3Izn319iIvffDreci3qDNT+t3lA5ylJ0/SoTaID8e0TPNUkHUSsgJZXEmLHvoYzrA==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
+        "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
       }
     },
     "@hapi/nigel": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-3.1.1.tgz",
-      "integrity": "sha512-R9YWx4S8yu0gcCBrMUDCiEFm1SQT895dMlYoeNBp8I6YhF1BFF1iYPueKA2Kkp9BvyHdjmvrxCOns7GMmpl+Fw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/vise": "3.x.x"
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
       }
     },
     "@hapi/pez": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-4.1.2.tgz",
-      "integrity": "sha512-8zSdJ8cZrJLFldTgwjU9Fb1JebID+aBCrCsycgqKYe0OZtM2r3Yv3aAwW5z97VsZWCROC1Vx6Mdn4rujh5Ktcg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
       "requires": {
-        "@hapi/b64": "4.x.x",
-        "@hapi/boom": "7.x.x",
-        "@hapi/content": "^4.1.1",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/nigel": "3.x.x"
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
       }
     },
     "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
     },
     "@hapi/podium": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-3.4.3.tgz",
-      "integrity": "sha512-QJlnYLEYZWlKQ9fSOtuUcpANyoVGwT68GA9P0iQQCAetBK0fI+nbRBt58+aMixoifczWZUthuGkNjqKxgPh/CQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.1.tgz",
+      "integrity": "sha512-jh7a6+5Z4FUWzx8fgmxjaAa1DTBu+Qfg+NbVdo0f++rE5DgsVidUYrLDp3db65+QjDLleA2MfKQXkpT8ylBDXA==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/shot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.2.tgz",
-      "integrity": "sha512-6LeHLjvsq/bQ0R+fhEyr7mqExRGguNTrxFZf5DyKe3CK6pNabiGgYO4JVFaRrLZ3JyuhkS0fo8iiRE2Ql2oA/A==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.4.tgz",
+      "integrity": "sha512-PcEz0WJgFDA3xNSMeONgQmothFr7jhbbRRSAKaDh7chN7zOXBlhl13bvKZW6CMb2xVfJUmt34CW3e/oExMgBhQ==",
       "requires": {
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/somever": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-2.1.1.tgz",
-      "integrity": "sha512-cic5Sto4KGd9B0oQSdKTokju+rYhCbdpzbMb0EBnrH5Oc1z048hY8PaZ1lx2vBD7I/XIfTQVQetBH57fU51XRA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.0.tgz",
+      "integrity": "sha512-Upw/kmKotC9iEmK4y047HMYe4LDKsE5NWfjgX41XNKmFvxsQL7OiaCWVhuyyhU0ShDGBfIAnCH8jZr49z/JzZA==",
       "requires": {
-        "@hapi/bounce": "1.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/statehood": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-6.1.2.tgz",
-      "integrity": "sha512-pYXw1x6npz/UfmtcpUhuMvdK5kuOGTKcJNfLqdNptzietK2UZH5RzNJSlv5bDHeSmordFM3kGItcuQWX2lj2nQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
+      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bounce": "1.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/cryptiles": "4.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/iron": "5.x.x",
-        "@hapi/joi": "16.x.x"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "16.1.8",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-          "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
-          "requires": {
-            "@hapi/address": "^2.1.2",
-            "@hapi/formula": "^1.2.0",
-            "@hapi/hoek": "^8.2.4",
-            "@hapi/pinpoint": "^1.0.2",
-            "@hapi/topo": "^3.1.3"
-          }
-        }
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
     "@hapi/subtext": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-6.1.3.tgz",
-      "integrity": "sha512-qWN6NbiHNzohVcJMeAlpku/vzbyH4zIpnnMPMPioQMwIxbPFKeNViDCNI6fVBbMPBiw/xB4FjqiJkRG5P9eWWg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.3.tgz",
+      "integrity": "sha512-CekDizZkDGERJ01C0+TzHlKtqdXZxzSWTOaH6THBrbOHnsr3GY+yiMZC+AfNCypfE17RaIakGIAbpL2Tk1z2+A==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/content": "^4.1.1",
-        "@hapi/file": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/pez": "^4.1.2",
-        "@hapi/wreck": "15.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
       }
     },
     "@hapi/teamwork": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-3.3.1.tgz",
-      "integrity": "sha512-61tiqWCYvMKP7fCTXy0M4VE6uNIwA0qvgFoiDubgfj7uqJ0fdHJFQNnVPGrxhLWlwz0uBPWrQlBH7r8y9vFITQ=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.0.tgz",
+      "integrity": "sha512-llqoQTrAJDTXxG3c4Kz/uzhBS1TsmSBa/XG5SPcVXgmffHE1nFtyLIK0hNJHCB3EuBKT84adzd1hZNY9GJLWtg=="
     },
     "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
       "requires": {
-        "@hapi/hoek": "^8.3.0"
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/validate": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.2.tgz",
+      "integrity": "sha512-ojg3iE/haKh8aCZFObkOzuJ1vQ8NP+EiuibliJKe01IMstBPXQc4Xl08+8zqAL+iZSZKp1TaWdwaNSzq8HIMKA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
       }
     },
     "@hapi/vise": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-3.1.1.tgz",
-      "integrity": "sha512-OXarbiCSadvtg+bSdVPqu31Z1JoBL+FwNYz3cYoBKQ5xq1/Cr4A3IkGpAZbAuxU5y4NL5pZFZG3d2a3ZGm/dOQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
       "requires": {
-        "@hapi/hoek": "8.x.x"
+        "@hapi/hoek": "9.x.x"
       }
     },
     "@hapi/wreck": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-15.1.0.tgz",
-      "integrity": "sha512-tQczYRTTeYBmvhsek/D49En/5khcShaBEmzrAaDjMrFXKJRuF8xA8+tlq1ETLBFwGd6Do6g2OC74rt11kzawzg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.0.0.tgz",
+      "integrity": "sha512-d8lqCinbKyDByn7GzJDRDbitddhIEydNm44UcAMejfhEH3o4IYvKYq6K8cAqXbilXPuvZc0ErlUOg9SDdgRtMw==",
       "requires": {
-        "@hapi/boom": "7.x.x",
-        "@hapi/bourne": "1.x.x",
-        "@hapi/hoek": "8.x.x"
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
       }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
@@ -416,12 +761,65 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@tokenizer/token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+    },
+    "@types/bl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-2.1.0.tgz",
+      "integrity": "sha512-1TdA9IXOy4sdqn8vgieQ6GZAiHiPNrOiO1s2GJjuYPw4QVY7gYoVjkW049avj33Ez7IcIvu43hQsMsoUFbCn2g==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/bn.js": {
@@ -432,10 +830,25 @@
         "@types/node": "*"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+    },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+      "version": "14.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.1.tgz",
+      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
     },
     "@types/pbkdf2": {
       "version": "3.1.0",
@@ -461,22 +874,27 @@
         "event-target-shim": "^5.0.0"
       }
     },
-    "abstract-leveldown": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
-      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+    "abortable-iterator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-3.0.0.tgz",
+      "integrity": "sha512-7KqcPPnMhfot4GrEjK51zesS4Ye/lUCHBgYt3oRxIlU24HO3mVxBwEo9niNyfHqoWKqWLuZTc3zErNomdHA+ag==",
       "requires": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "abstract-leveldown": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
+      "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
+      "requires": {
         "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
         "xtend": "~4.0.0"
       }
     },
     "abstract-logging": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-1.0.0.tgz",
-      "integrity": "sha1-i33q/TEFWbwo93ck3RuzAXcnjBs="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.0.tgz",
+      "integrity": "sha512-/oA9z7JszpIioo6J6dB79LVUgJ3eD3cxkAmdCkvWWS+Y9tPtALs1rLqOekLUXUbYqM2fB9TTK0ibAyZJJOP/CA=="
     },
     "accepts": {
       "version": "1.3.7",
@@ -512,19 +930,63 @@
       "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
       "requires": {
         "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "requires": {
-        "color-convert": "^1.9.0"
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      }
+    },
+    "any-signal": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-1.2.0.tgz",
+      "integrity": "sha512-Cl08k4xItix3jvu4cxO/dt2rQ6iUAjO66pTyRMub+WL1VXeAyZydCpD8GqWTPKfdL28U0R0UucmQVsUsBnvCmQ==",
+      "requires": {
+        "abort-controller": "^3.0.0"
       }
     },
     "args": {
@@ -538,10 +1000,41 @@
         "mri": "1.1.4"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
         "camelcase": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
           "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         }
       }
     },
@@ -549,6 +1042,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
       "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
+    },
+    "array-shuffle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-1.0.1.tgz",
+      "integrity": "sha1-fqSIKjVrS8pfVF4LblLq9tlxVXo="
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
@@ -571,26 +1069,10 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "assemblyscript": {
-      "version": "github:assemblyscript/assemblyscript#3ed76a97f05335504166fce1653da75f4face28f",
-      "from": "github:assemblyscript/assemblyscript#v0.6",
-      "requires": {
-        "@protobufjs/utf8": "^1.1.0",
-        "binaryen": "77.0.0-nightly.20190407",
-        "glob": "^7.1.3",
-        "long": "^4.0.0",
-        "opencollective-postinstall": "^2.0.0",
-        "source-map-support": "^0.5.11"
-      }
-    },
-    "assert": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
-      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
-      "requires": {
-        "object-assign": "^4.1.1",
-        "util": "0.10.3"
-      }
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "async": {
       "version": "2.6.3",
@@ -600,47 +1082,20 @@
         "lodash": "^4.17.14"
       }
     },
-    "async-iterator-all": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-all/-/async-iterator-all-1.0.0.tgz",
-      "integrity": "sha512-+vC2NFEmAuONF+A2MzM1tUS5pHovDH37/oQbmXW6FgnEns0S9BsR+MJGnzsFHzSN2iFQhbN7L8cFqV1W1F1kpQ=="
-    },
-    "async-iterator-batch": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/async-iterator-batch/-/async-iterator-batch-0.0.1.tgz",
-      "integrity": "sha512-bzsAEv8fXhJfDR/5qxgoDD3N8TJ8re6XfLeVBJfUt0KsYdVL/D+u05yTT78qnhtkNW9/hh0+NO/AHmSqz50eOQ=="
-    },
-    "async-iterator-first": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-first/-/async-iterator-first-1.0.0.tgz",
-      "integrity": "sha512-1PT9En58Uw1CZtcNUsrEUK5yXUxsKeaI5f7Y9/yEfQXeWObmbivvw+VZIyFL3T7BdUT1HvL2mKlHZdVpiJWCSQ=="
-    },
-    "async-iterator-last": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-last/-/async-iterator-last-1.0.0.tgz",
-      "integrity": "sha512-girbg1o/OdnszY9vbkIphzx71Gu0DNm+5DjGe32S1/bMLotPf52XFRRMVw/LE9/4Gn9xmL3H9tWftZ+JJWV4ig=="
-    },
-    "async-iterator-to-pull-stream": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-to-pull-stream/-/async-iterator-to-pull-stream-1.3.0.tgz",
-      "integrity": "sha512-NjyhAEz/sx32olqgKIk/2xbWEM6o8qef1yetIgb0U/R3oBgndP1kE/0CslowH3jvnA94BO4I6OXpOkTKH7Z1AA==",
-      "requires": {
-        "get-iterator": "^1.0.2",
-        "pull-stream-to-async-iterator": "^1.0.1"
-      }
-    },
-    "async-iterator-to-stream": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/async-iterator-to-stream/-/async-iterator-to-stream-1.2.0.tgz",
-      "integrity": "sha512-6R+mWdZgHpmXpvovdsl+/gidRgl0Wf18ADozWPA5isk9XBzJnzpVBH7qcZZbKG72eytJlNXBN3rWgmwzd4Wr8A==",
-      "requires": {
-        "readable-stream": "^3.0.5"
-      }
-    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atomic-sleep": {
       "version": "1.0.0",
@@ -665,11 +1120,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "base32-encode": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-1.1.1.tgz",
-      "integrity": "sha512-eqa0BeGghj3guezlasdHJhr3+J5ZbbQvxeprkcDMbRQrjlqOT832IUDT4Al4ofAwekFYMqkkM9KMUHs9Cu0HKA=="
-    },
     "base32.js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
@@ -690,6 +1140,15 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
+    "bcrypto": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.3.0.tgz",
+      "integrity": "sha512-SP48cpoc4BkEPNOErdsZ1VjbtdXY/C0f5wAywWniLne/Fd/5oOBqLbC6ZavngLvk4oik76g4I7PO5KduJoqECQ==",
+      "requires": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
+      }
+    },
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -708,16 +1167,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
       "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
     },
-    "binary-querystring": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/binary-querystring/-/binary-querystring-0.1.2.tgz",
-      "integrity": "sha512-mrot/6OS3YIUSWMyv/9uyMbCDYQWxl+fVDsrJFjPFGcVT0xDCdEg/gbN6eguaCr0UqsuXdtJ3DQ3i2z2alnulg=="
-    },
-    "binaryen": {
-      "version": "77.0.0-nightly.20190407",
-      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-77.0.0-nightly.20190407.tgz",
-      "integrity": "sha512-1mxYNvQ0xywMe582K7V6Vo2zzhZZxMTeGHH8aE/+/AND8f64D8Q1GThVY3RVRwGY/4p+p95ccw9Xbw2ovFXRIg=="
-    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -732,9 +1181,9 @@
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "bip174": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bip174/-/bip174-1.0.1.tgz",
-      "integrity": "sha512-Mq2aFs1TdMfxBpYPg7uzjhsiXbAtoVq44TNjEWtvuZBiBgc3m7+n55orYMtTAxdg7jWbL4DtH0MKocJER4xERQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
+      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
     },
     "bip32": {
       "version": "2.0.5",
@@ -748,6 +1197,13 @@
         "tiny-secp256k1": "^1.1.3",
         "typeforce": "^1.11.5",
         "wif": "^2.0.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
       }
     },
     "bip66": {
@@ -764,12 +1220,12 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "bitcoinjs-lib": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.10.tgz",
-      "integrity": "sha512-CesUqtBtnYc+SOMsYN9jWQWhdohW1MpklUkF7Ukn4HiAyN6yxykG+cIJogfRt6x5xcgH87K1Q+Mnoe/B+du1Iw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
+      "integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
       "requires": {
         "bech32": "^1.1.2",
-        "bip174": "^1.0.1",
+        "bip174": "^2.0.1",
         "bip32": "^2.0.4",
         "bip66": "^1.1.0",
         "bitcoin-ops": "^1.4.0",
@@ -786,11 +1242,13 @@
       }
     },
     "bl": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
-      "integrity": "sha512-jrCW5ZhfQ/Vt07WX1Ngs+yn9BDqPL/gw28S7s9H6QK/gupnizNzJAss5akW20ISgOrbLTlXOOCTJeNUQqruAWQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
-        "readable-stream": "^3.0.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "blakejs": {
@@ -803,18 +1261,18 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
+    "blob-to-it": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.2.tgz",
+      "integrity": "sha512-3/NRr0mUWQTkS71MYEC1teLbT5BTs7RZ6VMPXDV6qApjw3B4TAZspQuvDkYfHuD/XzL5p/RO91x5XRPeJvcCqg==",
+      "requires": {
+        "browser-readablestream-to-it": "^0.0.2"
+      }
+    },
     "bn.js": {
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
       "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-    },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "requires": {
-        "hoek": "6.x.x"
-      }
     },
     "borc": {
       "version": "2.1.2",
@@ -831,18 +1289,42 @@
       }
     },
     "boxen": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.2.0.tgz",
-      "integrity": "sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
       "requires": {
         "ansi-align": "^3.0.0",
         "camelcase": "^5.3.1",
-        "chalk": "^2.4.2",
+        "chalk": "^3.0.0",
         "cli-boxes": "^2.2.0",
-        "string-width": "^3.0.0",
-        "term-size": "^1.2.0",
-        "type-fest": "^0.3.0",
-        "widest-line": "^2.0.0"
+        "string-width": "^4.1.0",
+        "term-size": "^2.1.0",
+        "type-fest": "^0.8.1",
+        "widest-line": "^3.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "brace-expansion": {
@@ -859,6 +1341,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-readablestream-to-it": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.2.tgz",
+      "integrity": "sha512-bbiTccngeAbPmpTUJcUyr6JhivADKV9xkNJVLdA91vjdzXyFBZ6fgrzElQsV3k1UNGQACRTl3p4y+cEGG9U48A=="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -870,6 +1357,59 @@
         "evp_bytestokey": "^1.0.3",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+      "requires": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+          "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
+        }
       }
     },
     "bs58": {
@@ -900,47 +1440,34 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
     },
     "buffer-indexof": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz",
-      "integrity": "sha1-7Q82t64WamanzRdMBGeuje3wCPU="
-    },
-    "buffer-peek-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-peek-stream/-/buffer-peek-stream-1.1.0.tgz",
-      "integrity": "sha512-b3MXlJ52rPOL5xCAQsiCOy/tY9WXOP/hwATporJriUDxnT3MjJgVppDzTFegpg2Nw7NMS28MKC6IKvaXLnGr+Q=="
-    },
-    "buffer-reuse-pool": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-reuse-pool/-/buffer-reuse-pool-1.0.0.tgz",
-      "integrity": "sha512-rZlw21X5Bv2O1d4ZmMLXaR45UJ+1loUfxVKUG/hwSY/7IhISv6wZbi4ScHqugxTeuw6ndu7dtq4CATVUrr1MXg=="
-    },
-    "buffer-split": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-split/-/buffer-split-1.0.0.tgz",
-      "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
-      "requires": {
-        "buffer-indexof": "~0.0.0"
-      }
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g=="
     },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
-    "builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
     },
     "byteman": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/byteman/-/byteman-1.3.5.tgz",
       "integrity": "sha512-FzWDstifFRxtHX234b93AGa1b77dA6NUFpEXe+AoG1NydGN//XDZLMXxRNUoMf7SYYhVxfpwUEUgQOziearJvA=="
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -956,25 +1483,12 @@
         "responselike": "^1.0.2"
       },
       "dependencies": {
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
         "lowercase-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
         }
       }
-    },
-    "callbackify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
-      "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
     },
     "callsite": {
       "version": "1.0.0",
@@ -986,20 +1500,61 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
+    "cbor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.1.0.tgz",
+      "integrity": "sha512-qzEc7kUShdMbWTaUH7X+aHW8owvBU3FS0dfYR1lGYpoZr0mGJhhojLlZJH653x/DfeMZ56h315FRNBUIG1R7qg==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "nofilter": "^1.0.4"
+      }
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chai-checkmark": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/chai-checkmark/-/chai-checkmark-1.0.1.tgz",
       "integrity": "sha1-n7s8mtkQHwl+8ogyjTD0In10//s="
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "ci-info": {
       "version": "2.0.0",
@@ -1007,38 +1562,29 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cid-tool": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.3.0.tgz",
-      "integrity": "sha512-XVSG2zXSKuRTBsaWJOnb7c/ZzeZr3sjRRqQza9Y/5SFy9CHQqa53xWAMXj2BFqRSegn3Lt5zSJ1sLb1iPE+m8g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-1.0.0.tgz",
+      "integrity": "sha512-K7NGZBo1P6N2ogUmBtJWwMNfqXxU3ROiCHs+YKDDwBecsZ46J+9vJ6pOEJzds1JzqRnYRxxZBPfgBEYQebMXJg==",
       "requires": {
-        "cids": "~0.7.0",
+        "cids": "^1.0.0",
         "explain-error": "^1.0.4",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.14",
-        "yargs": "^13.2.2"
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
+        "split2": "^3.1.1",
+        "uint8arrays": "^1.1.0",
+        "yargs": "^15.0.2"
       }
     },
     "cids": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-      "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cids/-/cids-1.0.0.tgz",
+      "integrity": "sha512-HEBCIElSiXlkgZq3dgHJc3eDcnFteFp96N8/1/oqX5lkxBtB66sZ12jqEP3g7Ut++jEk6kIUGifQ1Qrya1jcNQ==",
       "requires": {
-        "buffer": "^5.5.0",
         "class-is": "^1.1.0",
-        "multibase": "~0.6.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15"
-      },
-      "dependencies": {
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        }
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "uint8arrays": "^1.0.0"
       }
     },
     "cipher-base": {
@@ -1066,24 +1612,13 @@
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "clone-deep": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-2.0.2.tgz",
-      "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
-      "requires": {
-        "for-own": "^1.0.0",
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.0",
-        "shallow-clone": "^1.0.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "clone-response": {
@@ -1095,17 +1630,25 @@
       }
     },
     "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.20.3",
@@ -1132,25 +1675,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "concat-stream": {
-      "version": "github:hugomrdias/concat-stream#057bc7b5d6d8df26c8cf00a3f151b6721a0a8034",
-      "from": "github:hugomrdias/concat-stream#feat/smaller",
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.0.2"
-      }
-    },
     "configstore": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
-      "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
       "requires": {
-        "dot-prop": "^4.1.0",
+        "dot-prop": "^5.2.0",
         "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
       }
     },
     "cookie": {
@@ -1167,6 +1702,15 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/crdts/-/crdts-0.1.5.tgz",
       "integrity": "sha512-4Z/dQqa9qzMPlrE+zd0ecl53QFwaTZVVYTUgxvpF0k8OcOy4HY7c+C9brXp81eigLE0EKENTVp3CjIMY9b/ezg=="
+    },
+    "create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
     },
     "create-hash": {
       "version": "1.2.0",
@@ -1194,96 +1738,115 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        }
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
     },
     "d64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d64/-/d64-1.0.0.tgz",
       "integrity": "sha1-QAKofoUMv8n52XBrYPymE6MzbpA="
     },
-    "data-queue": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/data-queue/-/data-queue-0.0.3.tgz",
-      "integrity": "sha512-6YOUFa/+lXklPO42RF4zIzzphG01Jp1eoWolzkQb6z5oVsSThLibZ63VmAze3KuIMTglFt551q8j0Zaswx5vGQ=="
+    "dag-cbor-links": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-2.0.0.tgz",
+      "integrity": "sha512-ra3oaFkrl57zcZf0l5F/L9l8QTdqdO9XZLpbXsNT0EX4NPL34RDN4r6Uuk6LI1WQLFfM0prSCbAEdOWxzUJo3A==",
+      "requires": {
+        "cids": "^1.0.0",
+        "ipld-dag-cbor": "^0.17.0"
+      }
     },
     "datastore-core": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.6.1.tgz",
-      "integrity": "sha512-bPMmMEHu96EaFS+OXeyjC0C1YnnQFiybvMszduYya7xlCpKiK24YgF/YZm1STj0IjI9zub9UkNw3eIBos2z9cw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-2.0.0.tgz",
+      "integrity": "sha512-E6SS3GEZNMCRZScWO98qQ14MIb7+3MLsJtcgla/ULCjfnhThsUE21HN+wT0+QLoYrKR54puWy/3XKp5N+5+zyA==",
       "requires": {
-        "async": "^2.6.1",
-        "interface-datastore": "~0.6.0",
-        "pull-many": "^1.0.8",
-        "pull-stream": "^3.6.9"
+        "debug": "^4.1.1",
+        "interface-datastore": "^2.0.0",
+        "ipfs-utils": "^2.3.1"
+      },
+      "dependencies": {
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        }
       }
     },
     "datastore-fs": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.8.1.tgz",
-      "integrity": "sha512-kSWQwTWa7Pf6HIBvJVQ0b8BvKqW6y22zWJ1Vp0h34R5loq48hOYQ++4ckZFWyzOvF3bJAi5X2euF01RPKqMJIQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-2.0.1.tgz",
+      "integrity": "sha512-W0qOEJDHVmzSfCXMBcgnHI7n0SROQ7vpD24v9AicVWE/DPju4CUWl/1NHSQO3RR3ooaFdG31c1J2OjDKJO6+Fg==",
       "requires": {
-        "async": "^2.6.1",
-        "datastore-core": "~0.6.0",
-        "fast-write-atomic": "~0.2.0",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.11",
-        "interface-datastore": "~0.6.0",
-        "mkdirp": "~0.5.1",
-        "pull-stream": "^3.6.9"
+        "datastore-core": "^2.0.0",
+        "fast-write-atomic": "^0.2.0",
+        "interface-datastore": "^2.0.0",
+        "it-glob": "0.0.8",
+        "mkdirp": "^1.0.4"
       }
     },
     "datastore-level": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.11.0.tgz",
-      "integrity": "sha512-kbxtHSI37EFpqy/u91VqZdzoFZMq11eRS7x9ZOtXDMToYJspyG7G8GXvq4NIB9+41+BZGIzNQuXL1M4SNoWtaA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-2.0.0.tgz",
+      "integrity": "sha512-52qSxZG75QRqO502cSvnYnXj/5sO29Dvtd9uuiRLSzUaSPher8pS0hl5xzlx7zglpzAjQpjaq9oy2UFO6vMn6g==",
       "requires": {
-        "datastore-core": "~0.6.0",
-        "encoding-down": "^6.0.2",
-        "interface-datastore": "~0.6.0",
-        "level-js": "github:timkuijsten/level.js#idbunwrapper",
-        "leveldown": "^5.0.0",
-        "levelup": "^4.0.1",
-        "pull-stream": "^3.6.9"
+        "datastore-core": "^2.0.0",
+        "interface-datastore": "^2.0.0",
+        "level": "^5.0.1"
       }
     },
     "datastore-pubsub": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.1.1.tgz",
-      "integrity": "sha512-yxAMVI51ZxuGaiEUQW0w3picNHHrUDvOIlgCdnMsa4pYgWi1R4jJAAV1tkYHTPUOXyp9UUIVnNyoeJ/CSLjlzA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.4.1.tgz",
+      "integrity": "sha512-OVKIlSqILBSFApJ5FPmiWaSA71l53sX52sV0JgyGBaghzqbFTTB1HQikB8npSyGMEJfmpCVhKue9rkTHF+WoXg==",
       "requires": {
-        "assert": "^1.4.1",
-        "debug": "^4.1.0",
-        "err-code": "^1.1.2",
-        "interface-datastore": "~0.6.0",
-        "multibase": "~0.6.0"
+        "debug": "^4.1.1",
+        "err-code": "^2.0.3",
+        "interface-datastore": "^2.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "dateformat": {
@@ -1310,6 +1873,14 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "requires": {
+        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -1345,23 +1916,79 @@
         }
       }
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        }
+      }
+    },
+    "delay": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
+      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "delimit-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
       "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+    },
+    "des.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
     },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
+    "diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
-        "streamsearch": "0.1.2"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
+    },
+    "dirty-chai": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
+      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w=="
     },
     "dlv": {
       "version": "1.1.3",
@@ -1383,11 +2010,11 @@
       "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE="
     },
     "dot-prop": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "^2.0.0"
       }
     },
     "drbg.js": {
@@ -1420,9 +2047,9 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encoding-down": {
       "version": "6.3.0",
@@ -1433,6 +2060,20 @@
         "inherits": "^2.0.3",
         "level-codec": "^9.0.0",
         "level-errors": "^2.0.0"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
+          "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -1454,13 +2095,6 @@
         "debug": "~4.1.0",
         "engine.io-parser": "~2.2.0",
         "ws": "^7.1.2"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
-        }
       }
     },
     "engine.io-client": {
@@ -1508,28 +2142,10 @@
         "has-binary2": "~1.0.2"
       }
     },
-    "epimetheus": {
-      "version": "1.0.92",
-      "resolved": "https://registry.npmjs.org/epimetheus/-/epimetheus-1.0.92.tgz",
-      "integrity": "sha512-rZqoUT63Xu3z5wPpTFPWkrIileJ9deOx/k/0ZPTiMSKBtPmJ9RzNrlo/M2UWvky7h8clrgc/s2uciq2mfruKrA==",
-      "requires": {
-        "prom-client": "^10.0.0"
-      },
-      "dependencies": {
-        "prom-client": {
-          "version": "10.2.3",
-          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
-          "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
-          "requires": {
-            "tdigest": "^0.1.1"
-          }
-        }
-      }
-    },
     "err-code": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
     },
     "errno": {
       "version": "0.1.7",
@@ -1538,6 +2154,11 @@
       "requires": {
         "prr": "~1.0.1"
       }
+    },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1564,23 +2185,6 @@
         "scrypt-js": "^3.0.0",
         "secp256k1": "^4.0.1",
         "setimmediate": "^1.0.5"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
-        },
-        "secp256k1": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-          "requires": {
-            "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        }
       }
     },
     "ethereumjs-account": {
@@ -1634,11 +2238,6 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
           }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "level-codec": {
           "version": "7.0.1",
@@ -1788,50 +2387,40 @@
       }
     },
     "ethers": {
-      "version": "4.0.48",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
-      "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.14.tgz",
+      "integrity": "sha512-6WkoYwAURTr/4JiSZlrMJ9mm3pBv/bWrOu7sVXdLGw9QU4cp/GDZVrKKnh5GafMTzanuNBJoaEanPCjsbe4Mig==",
       "requires": {
-        "aes-js": "3.0.0",
-        "bn.js": "^4.4.0",
-        "elliptic": "6.5.3",
-        "hash.js": "1.1.3",
-        "js-sha3": "0.5.7",
-        "scrypt-js": "2.0.4",
-        "setimmediate": "1.0.4",
-        "uuid": "2.0.1",
-        "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
+        "@ethersproject/abi": "^5.0.5",
+        "@ethersproject/abstract-provider": "^5.0.4",
+        "@ethersproject/abstract-signer": "^5.0.4",
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/base64": "^5.0.3",
+        "@ethersproject/basex": "^5.0.3",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/contracts": "^5.0.4",
+        "@ethersproject/hash": "^5.0.4",
+        "@ethersproject/hdnode": "^5.0.4",
+        "@ethersproject/json-wallets": "^5.0.6",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/networks": "^5.0.3",
+        "@ethersproject/pbkdf2": "^5.0.3",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/providers": "^5.0.8",
+        "@ethersproject/random": "^5.0.3",
+        "@ethersproject/rlp": "^5.0.3",
+        "@ethersproject/sha2": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4",
+        "@ethersproject/solidity": "^5.0.4",
+        "@ethersproject/strings": "^5.0.4",
+        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/units": "^5.0.4",
+        "@ethersproject/wallet": "^5.0.4",
+        "@ethersproject/web": "^5.0.6",
+        "@ethersproject/wordlists": "^5.0.4"
       }
     },
     "ethjs-util": {
@@ -1843,6 +2432,11 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "event-iterator": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ=="
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -1852,6 +2446,11 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "events": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -1863,24 +2462,19 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        }
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
       }
     },
     "explain-error": {
@@ -1888,10 +2482,10 @@
       "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
       "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
-    "fast-future": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+    "fast-fifo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+      "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
     },
     "fast-redact": {
       "version": "2.0.0",
@@ -1909,9 +2503,15 @@
       "integrity": "sha512-WvJe06IfNYlr+6cO3uQkdKdy3Cb1LlCJSF8zRs2eT8yuhdbSlR9nIt+TgQ92RUxiRrQm+/S7RARnMfCs5iuAjw=="
     },
     "file-type": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-11.1.0.tgz",
-      "integrity": "sha512-rM0UO7Qm9K7TWTtA6AShI/t7H5BPjDeGVDaNyg9BjHAj3PysKy7+8C8D137R88jnR3rFJZQB/tFgydl5sN5m7g=="
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
+      "integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
+      "requires": {
+        "readable-web-to-node-stream": "^2.0.0",
+        "strtok3": "^6.0.3",
+        "token-types": "^2.0.0",
+        "typedarray-to-buffer": "^3.1.5"
+      }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -1919,22 +2519,18 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filesize": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
-      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg=="
     },
     "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       }
-    },
-    "flatmap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
-      "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
     },
     "flatstr": {
       "version": "1.0.12",
@@ -1946,44 +2542,31 @@
       "resolved": "https://registry.npmjs.org/fnv1a/-/fnv1a-1.0.1.tgz",
       "integrity": "sha1-kV4tbQI8Q9UiStn20qPEFW9XEvU="
     },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+    "form-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
-        "for-in": "^1.0.1"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fsm/-/fsm-1.0.2.tgz",
-      "integrity": "sha1-4uubKXR+gGu7kPjVRT4vnXvSN4M=",
-      "requires": {
-        "split": "~0.3.0"
-      }
-    },
-    "fsm-event": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fsm-event/-/fsm-event-2.1.0.tgz",
-      "integrity": "sha1-04VxbtOPnJL+qyumAeKqxsC6WpI=",
-      "requires": {
-        "fsm": "^1.0.2"
-      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2495,15 +3078,23 @@
         "tiny-each-async": "2.0.3"
       }
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+    },
     "get-iterator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
       "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -2519,11 +3110,19 @@
       }
     },
     "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.0.1.tgz",
+      "integrity": "sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==",
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "^1.3.5"
+      }
+    },
+    "globalthis": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
+      "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "got": {
@@ -2551,6 +3150,11 @@
           "requires": {
             "pump": "^3.0.0"
           }
+        },
+        "p-cancelable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+          "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
         }
       }
     },
@@ -2560,9 +3164,9 @@
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "hamt-sharding": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-0.0.2.tgz",
-      "integrity": "sha512-0pUBRvsdM1G6RgXfJASUMLwk++LQMNoXx2n2iMZiSzV43lBNesSz130wkGSP2D6d/8DYIWABLL1Vqb4PpcUcvQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-1.0.0.tgz",
+      "integrity": "sha512-jDk8N1U8qprvSt3KopOrrP46zUogxeZY+znDHP196MLBQKldld0TQFTneT1bxOFDw8vttbAQy1bG7L3/pzYorg==",
       "requires": {
         "sparse-array": "^1.3.1"
       }
@@ -2840,14 +3444,14 @@
       }
     },
     "hapi-pino": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-6.5.0.tgz",
-      "integrity": "sha512-262F+AJpNHCCGIPpqugPtVWU2plXyCcjeXkbcrD60LRg/tcobLAHuzR6usNcKCansJbrcCy+/kBXYcKQGae7+g==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/hapi-pino/-/hapi-pino-8.3.0.tgz",
+      "integrity": "sha512-8Cm1WIs6jp8B9ZzYqPFbCWNKt6F6jNCfLmCIHmPsm35sTOvT/r5+d9KpYR2vigWQRLS23VBXzOqUVESpP7r+jA==",
       "requires": {
-        "@hapi/hoek": "^8.3.0",
-        "abstract-logging": "^1.0.0",
-        "pino": "^5.13.5",
-        "pino-pretty": "^3.2.2"
+        "@hapi/hoek": "^9.0.0",
+        "abstract-logging": "^2.0.0",
+        "pino": "^6.0.0",
+        "pino-pretty": "^4.0.0"
       }
     },
     "has-binary2": {
@@ -2914,11 +3518,6 @@
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
       "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
-    "hi-base32": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.0.tgz",
-      "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2928,11 +3527,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "http-cache-semantics": {
       "version": "4.1.0",
@@ -2944,13 +3538,10 @@
       "resolved": "https://registry.npmjs.org/http2/-/http2-3.3.7.tgz",
       "integrity": "sha512-puSi8M8WNlFJm9Pk4c/Mbz9Gwparuj3gO9/RRO5zv6piQ0FY+9Qywp0PdWshYgsMJSalixFY7eC6oPu0zRxLAQ=="
     },
-    "human-to-milliseconds": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/human-to-milliseconds/-/human-to-milliseconds-1.0.0.tgz",
-      "integrity": "sha512-Rp1uvdGYHZ8v6GCl3N6QW48MlABqvLCzKbeNPPddbFdDEC7G1G+8oq0hmCiem4PSJIDwLvAxkPi3FF5BDoeKew==",
-      "requires": {
-        "promisify-es6": "^1.0.3"
-      }
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "humble-localstorage": {
       "version": "1.4.2",
@@ -2961,23 +3552,15 @@
         "localstorage-memory": "^1.0.1"
       }
     },
-    "idb-readable-stream": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
-      "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
-      "requires": {
-        "xtend": "^4.0.1"
-      }
-    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "immediate": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
-      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -3018,25 +3601,40 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
-    "interface-connection": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.3.tgz",
-      "integrity": "sha512-OV9Rj7AhUlssWJTO6nOazJdPFGqWDOVZ3j5aM+i0RPKyTzR87vJ949VqhMyKkCIR0GBAaNqfB7F4YA70a/QWiw==",
-      "requires": {
-        "pull-defer": "~0.2.3"
-      }
-    },
     "interface-datastore": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.6.0.tgz",
-      "integrity": "sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-2.0.0.tgz",
+      "integrity": "sha512-wOImix5uVEZWo+8zPSRMJ9nHbszZi3PhZ14KHLN7oRQjaYQtjtOpYj6n5EXTjDAfIQI8KN9vntHXxyAw1lcRIA==",
       "requires": {
-        "async": "^2.6.1",
         "class-is": "^1.1.0",
-        "err-code": "^1.1.2",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "uuid": "^3.2.2"
+        "err-code": "^2.0.1",
+        "ipfs-utils": "^2.3.1",
+        "iso-random-stream": "^1.1.1",
+        "it-all": "^1.0.2",
+        "it-drain": "^1.0.1",
+        "nanoid": "^3.0.2"
+      },
+      "dependencies": {
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        }
       }
     },
     "ip": {
@@ -3045,9 +3643,9 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-address": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.3.0.tgz",
-      "integrity": "sha512-tYN6DnF82jBRA6ZT3C+k4LBtVUKu0Taq7GZN4yldhz6nFKVh3EDg/zRIABsu4fAT2N0iFW9D482Aqkiah1NxTg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
+      "integrity": "sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==",
       "requires": {
         "jsbn": "1.1.0",
         "lodash.find": "4.6.0",
@@ -3064,1010 +3662,526 @@
       "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
     },
     "ipfs": {
-      "version": "0.36.4",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.36.4.tgz",
-      "integrity": "sha512-DRxX5N3D+qMpNs8/RShIIk7Ilb1Zce4ZdrGf+HWarLF0ljbZ4ZVLMJy9mAbC7mEiic+wtgwGLw4ACZHe3xIMQw==",
+      "version": "0.50.2",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.50.2.tgz",
+      "integrity": "sha512-mgXab5fxyUwQpy/NNfOCplql+Em2DhyWLYjTOgIaaCrWTssejeZyRETBYZazAwIk1xNsIDX3IgOfXlzWw850bw==",
       "requires": {
-        "@hapi/ammo": "^3.1.0",
-        "@hapi/hapi": "^18.3.1",
-        "@hapi/joi": "^15.0.1",
-        "async": "^2.6.1",
-        "async-iterator-all": "^1.0.0",
-        "async-iterator-to-pull-stream": "^1.1.0",
-        "async-iterator-to-stream": "^1.1.0",
-        "base32.js": "~0.1.0",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hapi": "^20.0.0",
+        "abort-controller": "^3.0.0",
+        "any-signal": "^1.1.0",
+        "array-shuffle": "^1.0.1",
         "bignumber.js": "^9.0.0",
-        "binary-querystring": "~0.1.2",
-        "bl": "^3.0.0",
-        "boom": "^7.2.0",
-        "bs58": "^4.0.1",
-        "buffer-peek-stream": "^1.0.1",
+        "bl": "^4.0.2",
         "byteman": "^1.3.5",
-        "callbackify": "^1.1.0",
-        "cid-tool": "~0.3.0",
-        "cids": "~0.7.1",
+        "cbor": "^5.0.1",
+        "cid-tool": "^1.0.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "datastore-core": "~0.6.0",
-        "datastore-pubsub": "~0.1.1",
+        "dag-cbor-links": "^2.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-pubsub": "^0.4.0",
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
-        "err-code": "^1.1.2",
-        "file-type": "^11.1.0",
+        "err-code": "^2.0.0",
+        "execa": "^4.0.0",
+        "file-type": "^14.1.4",
         "fnv1a": "^1.0.1",
-        "fsm-event": "^2.1.0",
         "get-folder-size": "^2.0.0",
-        "glob": "^7.1.3",
-        "hapi-pino": "^6.0.0",
-        "human-to-milliseconds": "^1.0.0",
-        "interface-datastore": "~0.6.0",
-        "ipfs-bitswap": "~0.24.1",
-        "ipfs-block": "~0.8.1",
-        "ipfs-block-service": "~0.15.1",
-        "ipfs-http-client": "^32.0.0",
-        "ipfs-http-response": "~0.3.0",
-        "ipfs-mfs": "~0.11.4",
-        "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.26.6",
-        "ipfs-unixfs": "~0.1.16",
-        "ipfs-unixfs-exporter": "~0.37.6",
-        "ipfs-unixfs-importer": "~0.39.9",
-        "ipfs-utils": "~0.0.3",
-        "ipld": "~0.24.1",
-        "ipld-bitcoin": "~0.3.0",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.4",
-        "ipld-ethereum": "^4.0.0",
-        "ipld-git": "~0.5.0",
-        "ipld-raw": "^4.0.0",
-        "ipld-zcash": "~0.3.0",
-        "ipns": "~0.5.2",
-        "is-ipfs": "~0.6.1",
-        "is-pull-stream": "~0.0.0",
-        "is-stream": "^2.0.0",
-        "iso-url": "~0.4.6",
-        "just-flatten-it": "^2.1.0",
+        "hamt-sharding": "^1.0.0",
+        "hapi-pino": "^8.2.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^2.0.0",
+        "ipfs-bitswap": "^3.0.0",
+        "ipfs-block-service": "^0.18.0",
+        "ipfs-core-utils": "^0.4.0",
+        "ipfs-http-client": "^47.0.1",
+        "ipfs-http-response": "^0.6.0",
+        "ipfs-repo": "^6.0.3",
+        "ipfs-unixfs": "^2.0.2",
+        "ipfs-unixfs-exporter": "^3.0.2",
+        "ipfs-unixfs-importer": "^3.0.2",
+        "ipfs-utils": "^3.0.0",
+        "ipld": "^0.27.1",
+        "ipld-bitcoin": "^0.4.0",
+        "ipld-block": "^0.10.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-ethereum": "^5.0.1",
+        "ipld-git": "^0.6.1",
+        "ipld-raw": "^6.0.0",
+        "ipld-zcash": "^0.5.0",
+        "ipns": "^0.8.0",
+        "is-domain-name": "^1.0.1",
+        "is-ipfs": "^2.0.0",
+        "iso-url": "^0.4.7",
+        "it-all": "^1.0.1",
+        "it-concat": "^1.0.0",
+        "it-drain": "^1.0.1",
+        "it-first": "^1.0.1",
+        "it-glob": "0.0.8",
+        "it-last": "^1.0.2",
+        "it-map": "^1.0.2",
+        "it-multipart": "^1.0.1",
+        "it-pipe": "^1.1.0",
+        "it-tar": "^1.2.2",
+        "it-to-stream": "^0.1.1",
+        "iterable-ndjson": "^1.1.0",
+        "joi": "^17.2.1",
+        "jsondiffpatch": "^0.4.1",
         "just-safe-set": "^2.1.0",
-        "kind-of": "^6.0.2",
-        "libp2p": "~0.25.3",
-        "libp2p-bootstrap": "~0.9.3",
-        "libp2p-crypto": "~0.16.0",
-        "libp2p-kad-dht": "~0.15.1",
-        "libp2p-keychain": "~0.4.1",
-        "libp2p-mdns": "~0.12.0",
-        "libp2p-record": "~0.6.3",
-        "libp2p-secio": "~0.11.0",
-        "libp2p-tcp": "~0.13.0",
-        "libp2p-webrtc-star": "~0.16.0",
-        "libp2p-websocket-star-multi": "~0.4.3",
-        "libp2p-websockets": "~0.12.2",
-        "lodash": "^4.17.11",
-        "mafmt": "^6.0.2",
-        "merge-options": "^1.0.1",
-        "mime-types": "^2.1.21",
-        "mkdirp": "~0.5.1",
-        "multiaddr": "^6.0.5",
-        "multiaddr-to-uri": "^4.0.1",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.6.0",
-        "node-fetch": "^2.3.0",
-        "peer-book": "~0.9.0",
-        "peer-id": "~0.12.0",
-        "peer-info": "~0.15.0",
+        "libp2p": "^0.29.0",
+        "libp2p-bootstrap": "^0.12.0",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-delegated-content-routing": "^0.7.0",
+        "libp2p-delegated-peer-routing": "^0.7.0",
+        "libp2p-floodsub": "^0.23.0",
+        "libp2p-gossipsub": "^0.6.0",
+        "libp2p-kad-dht": "^0.20.0",
+        "libp2p-mdns": "^0.15.0",
+        "libp2p-mplex": "^0.10.0",
+        "libp2p-noise": "^2.0.0",
+        "libp2p-record": "^0.9.0",
+        "libp2p-secio": "^0.13.0",
+        "libp2p-tcp": "^0.15.0",
+        "libp2p-webrtc-star": "^0.20.0",
+        "libp2p-websockets": "^0.14.0",
+        "mafmt": "^8.0.0",
+        "merge-options": "^2.0.0",
+        "mortice": "^2.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
+        "p-defer": "^3.0.0",
+        "p-queue": "^6.1.0",
+        "parse-duration": "^0.4.4",
+        "peer-id": "^0.14.0",
+        "pretty-bytes": "^5.3.0",
         "progress": "^2.0.1",
-        "prom-client": "^11.1.3",
-        "prometheus-gc-stats": "~0.6.0",
-        "promisify-es6": "^1.0.3",
-        "protons": "^1.0.1",
-        "pull-abortable": "^4.1.1",
-        "pull-cat": "^1.1.11",
-        "pull-defer": "~0.2.3",
-        "pull-file": "^1.1.0",
-        "pull-mplex": "~0.1.1",
-        "pull-ndjson": "~0.1.1",
-        "pull-pushable": "^2.2.0",
-        "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.9",
-        "pull-stream-to-async-iterator": "^1.0.1",
-        "pull-stream-to-stream": "^1.3.4",
-        "pull-traverse": "^1.0.3",
-        "readable-stream": "^3.4.0",
-        "receptacle": "^1.3.2",
-        "semver": "^6.1.1",
-        "stream-to-pull-stream": "^1.7.3",
-        "superstruct": "~0.6.0",
-        "tar-stream": "^2.0.0",
-        "temp": "~0.9.0",
-        "update-notifier": "^3.0.0",
-        "uri-to-multiaddr": "^3.0.1",
+        "prom-client": "^12.0.0",
+        "prometheus-gc-stats": "^0.6.0",
+        "protons": "^2.0.0",
+        "semver": "^7.3.2",
+        "stream-to-it": "^0.2.1",
+        "streaming-iterables": "^5.0.0",
+        "temp": "^0.9.0",
+        "timeout-abort-controller": "^1.1.0",
+        "uint8arrays": "^1.1.0",
+        "update-notifier": "^4.0.0",
+        "uri-to-multiaddr": "^4.0.0",
         "varint": "^5.0.0",
-        "yargs": "^13.2.4",
+        "yargs": "^15.1.0",
         "yargs-promise": "^1.1.0"
-      },
-      "dependencies": {
-        "ipfs-http-client": {
-          "version": "32.0.1",
-          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-32.0.1.tgz",
-          "integrity": "sha512-uDJjjAg9zvuiAucBE/o0I+xHu9Q9ZoLvj0cTyk+Jf+0duom1iIt2iEEN1HW+PNnZu12zYQWV3sB+tI5TN2lo7A==",
-          "requires": {
-            "async": "^2.6.1",
-            "bignumber.js": "^8.0.2",
-            "bl": "^3.0.0",
-            "bs58": "^4.0.1",
-            "buffer": "^5.2.1",
-            "cids": "~0.7.1",
-            "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
-            "debug": "^4.1.0",
-            "detect-node": "^2.0.4",
-            "end-of-stream": "^1.4.1",
-            "err-code": "^1.1.2",
-            "flatmap": "0.0.3",
-            "glob": "^7.1.3",
-            "ipfs-block": "~0.8.1",
-            "ipfs-utils": "~0.0.3",
-            "ipld-dag-cbor": "~0.15.0",
-            "ipld-dag-pb": "~0.17.3",
-            "is-ipfs": "~0.6.1",
-            "is-pull-stream": "0.0.0",
-            "is-stream": "^2.0.0",
-            "iso-stream-http": "~0.1.2",
-            "iso-url": "~0.4.6",
-            "just-kebab-case": "^1.1.0",
-            "just-map-keys": "^1.1.0",
-            "kind-of": "^6.0.2",
-            "lru-cache": "^5.1.1",
-            "multiaddr": "^6.0.6",
-            "multibase": "~0.6.0",
-            "multicodec": "~0.5.1",
-            "multihashes": "~0.4.14",
-            "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-            "once": "^1.4.0",
-            "peer-id": "~0.12.2",
-            "peer-info": "~0.15.1",
-            "promisify-es6": "^1.0.3",
-            "pull-defer": "~0.2.3",
-            "pull-stream": "^3.6.9",
-            "pull-to-stream": "~0.1.1",
-            "pump": "^3.0.0",
-            "qs": "^6.5.2",
-            "readable-stream": "^3.1.1",
-            "stream-to-pull-stream": "^1.7.2",
-            "tar-stream": "^2.0.1",
-            "through2": "^3.0.1"
-          },
-          "dependencies": {
-            "bignumber.js": {
-              "version": "8.1.1",
-              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-              "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
-            }
-          }
-        }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.24.1.tgz",
-      "integrity": "sha512-fqnqCgeyHb0CO12uptBbDNGMSV4aOz4xi2Fc+OcyBb7bgLa7GcBuMi01iaFnwqPcz9BQSKvZKNMP+Vx+OZusNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-3.0.0.tgz",
+      "integrity": "sha512-9rX9vMUEegk61O4OoUWBUcU/WLLwALhyzHQdJzqW1DCn+nNnZVbRrzIWY1v5PnlywMtcUvd/ennpegVKCPuiUA==",
       "requires": {
-        "async": "^2.6.1",
-        "bignumber.js": "^8.0.1",
-        "cids": "~0.7.0",
+        "abort-controller": "^3.0.0",
+        "any-signal": "^1.1.0",
+        "bignumber.js": "^9.0.0",
+        "cids": "^1.0.0",
         "debug": "^4.1.0",
-        "ipfs-block": "~0.8.0",
+        "ipld-block": "^0.10.0",
+        "it-length-prefixed": "^3.0.0",
+        "it-pipe": "^1.1.0",
         "just-debounce-it": "^1.1.0",
-        "lodash.isequalwith": "^4.4.0",
+        "libp2p-interfaces": "^0.4.1",
         "moving-average": "^1.0.0",
-        "multicodec": "~0.5.0",
-        "multihashing-async": "~0.5.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9",
-        "varint-decoder": "~0.1.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
-        },
-        "multihashing-async": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
-    "ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
-      "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
+        "protons": "^2.0.0",
+        "streaming-iterables": "^5.0.2",
+        "uint8arrays": "^1.1.0",
+        "varint-decoder": "^1.0.0"
       }
     },
     "ipfs-block-service": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.15.2.tgz",
-      "integrity": "sha512-iudmJO7UJZHonWoXyakuzy+bpV/7QVDm/g8eCqKN2BvhSjnLepaxdTyaXxJ76F2EOav1hdBP+U3Z9Mg/aCFPgg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.18.0.tgz",
+      "integrity": "sha512-tye5Uxbf3bYlfcGkV3CspP2JNcM2Ggm/5Kxph0jGKtAZtgfFxUq3NeSmvS6nGtZZBaFP4nwRF2yq7dQMALWzVg==",
       "requires": {
-        "async": "^2.6.1"
+        "err-code": "^2.0.0",
+        "streaming-iterables": "^5.0.2"
+      }
+    },
+    "ipfs-core-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.4.0.tgz",
+      "integrity": "sha512-IBPFvYjWPfVFpCeYUL/0gCUOabdBhh7aO5i4tU//UlF2gVCXPH4PRYlbBH9WM83zE2+o4vDi+dBXsdAI6nLPAg==",
+      "requires": {
+        "blob-to-it": "0.0.2",
+        "browser-readablestream-to-it": "0.0.2",
+        "cids": "^1.0.0",
+        "err-code": "^2.0.0",
+        "ipfs-utils": "^3.0.0",
+        "it-all": "^1.0.1",
+        "it-map": "^1.0.2",
+        "it-peekable": "0.0.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "ipfs-http-client": {
-      "version": "30.1.4",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-30.1.4.tgz",
-      "integrity": "sha512-ordvoPT3lAFL5qsvdYBeDGRP03gtbL6Jl+qJ9dztyhE7NJf2yhtnU3ZNqN1JMCcUK0qpGsDzX89t8dKQvI80Pw==",
+      "version": "47.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-47.0.1.tgz",
+      "integrity": "sha512-IAQf+uTLvXw5QFOzbyhu/5lH3rn7jEwwwdCGaNKVhoPI7yfyOV0wRse3hVWejjP1Id0P9mKuMKG8rhcY7pVAdQ==",
       "requires": {
-        "async": "^2.6.1",
-        "bignumber.js": "^8.0.2",
-        "bl": "^3.0.0",
-        "bs58": "^4.0.1",
-        "buffer": "^5.2.1",
-        "cids": "~0.5.5",
-        "concat-stream": "github:hugomrdias/concat-stream#feat/smaller",
+        "abort-controller": "^3.0.0",
+        "any-signal": "^1.1.0",
+        "bignumber.js": "^9.0.0",
+        "cids": "^1.0.0",
         "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "end-of-stream": "^1.4.1",
-        "err-code": "^1.1.2",
-        "flatmap": "0.0.3",
-        "glob": "^7.1.3",
-        "ipfs-block": "~0.8.0",
-        "ipld-dag-cbor": "~0.13.1",
-        "ipld-dag-pb": "~0.15.3",
-        "is-ipfs": "~0.6.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^1.1.0",
-        "iso-stream-http": "~0.1.2",
-        "iso-url": "~0.4.6",
-        "just-kebab-case": "^1.1.0",
-        "just-map-keys": "^1.1.0",
-        "lru-cache": "^5.1.1",
-        "multiaddr": "^6.0.6",
-        "multibase": "~0.6.0",
-        "multicodec": "~0.5.0",
-        "multihashes": "~0.4.14",
-        "ndjson": "github:hugomrdias/ndjson#feat/readable-stream3",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "promisify-es6": "^1.0.3",
-        "pull-defer": "~0.2.3",
-        "pull-stream": "^3.6.9",
-        "pull-to-stream": "~0.1.1",
-        "pump": "^3.0.0",
-        "qs": "^6.5.2",
-        "readable-stream": "^3.1.1",
-        "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^2.0.1",
-        "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
-        },
-        "cids": {
-          "version": "0.5.8",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.8.tgz",
-          "integrity": "sha512-Ye8TZP3YQfy0j+i5k+LPHdTY3JOvTwN1pxds44p6BRUv8PTMOAF/Vt4Bc+oiIQ0Sktn0iftkUHgqKNHIMwhshA==",
-          "requires": {
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "~0.5.0",
-            "multihashes": "~0.4.14"
-          }
-        },
-        "ipld-dag-cbor": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.1.tgz",
-          "integrity": "sha512-96KKh5XUq9LrWE/TQ/BOJ5FcQx7UZ892N76ufDdovq+fIwZ4/YpPRTAVssLUuN3crATHoGu80TVZMgevsuTCdQ==",
-          "requires": {
-            "borc": "^2.1.0",
-            "bs58": "^4.0.1",
-            "cids": "~0.5.5",
-            "is-circular": "^1.0.2",
-            "multihashes": "~0.4.14",
-            "multihashing-async": "~0.5.1",
-            "traverse": "~0.6.6"
-          }
-        },
-        "ipld-dag-pb": {
-          "version": "0.15.3",
-          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.15.3.tgz",
-          "integrity": "sha512-J1RJzSVCaOpxPmSzXbwVNsAZPHctjY4OjqG1dMIG86Z37CKvuy1QwCFkDhNccUTcQpF3sXfj5e0ZUyMM035vzg==",
-          "requires": {
-            "async": "^2.6.1",
-            "bs58": "^4.0.1",
-            "cids": "~0.5.4",
-            "class-is": "^1.1.0",
-            "is-ipfs": "~0.6.0",
-            "multihashing-async": "~0.5.1",
-            "protons": "^1.0.1",
-            "pull-stream": "^3.6.9",
-            "pull-traverse": "^1.0.3",
-            "stable": "~0.1.8"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-        },
-        "multihashing-async": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
+        "form-data": "^3.0.0",
+        "ipfs-core-utils": "^0.4.0",
+        "ipfs-utils": "^3.0.0",
+        "ipld-block": "^0.10.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-raw": "^6.0.0",
+        "iso-url": "^0.4.7",
+        "it-last": "^1.0.2",
+        "it-map": "^1.0.2",
+        "it-tar": "^1.2.2",
+        "it-to-buffer": "^1.0.0",
+        "it-to-stream": "^0.1.1",
+        "merge-options": "^2.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "nanoid": "^3.0.2",
+        "node-fetch": "^2.6.0",
+        "parse-duration": "^0.4.4",
+        "stream-to-it": "^0.2.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "ipfs-http-response": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.3.1.tgz",
-      "integrity": "sha512-C2Ld9/MVnUujXPLVGLYJEgi9troi0QLyhkygsQ6c4c9VG7/BYES+t45N6uM2Be8TkAAMIWFkXSi5zfoGcHCOsA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.6.0.tgz",
+      "integrity": "sha512-x1x4ZGvR0azgasT2ql6qKjiH+aPVjra9rJbNq89KzQVxrQLf9zlEHfLzfL7p8m0iYY4MiD+fW+QZF8xA18Xh2g==",
       "requires": {
-        "async": "^2.6.1",
-        "cids": "~0.7.1",
         "debug": "^4.1.1",
-        "file-type": "^8.0.0",
-        "filesize": "^3.6.1",
-        "get-stream": "^3.0.0",
-        "ipfs-unixfs": "~0.1.16",
-        "mime-types": "^2.1.21",
-        "multihashes": "~0.4.14",
-        "promisify-es6": "^1.0.3",
-        "stream-to-blob": "^1.0.1"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
-        }
+        "file-type": "^14.7.1",
+        "filesize": "^6.1.0",
+        "it-buffer": "^0.1.1",
+        "it-concat": "^1.0.0",
+        "it-reader": "^2.1.0",
+        "it-to-stream": "^0.1.1",
+        "mime-types": "^2.1.27",
+        "multihashes": "^3.0.1",
+        "p-try-each": "^1.0.1"
       }
     },
     "ipfs-log": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.3.6.tgz",
-      "integrity": "sha512-7lEW5tXITcmHHP9dT93mRI+burUm2WdEkjYQ+ERFSL3K9xH5aXMr96IQKnZpFoA6duIwquydlDsiYTXLh6g/Ag==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/ipfs-log/-/ipfs-log-4.6.5.tgz",
+      "integrity": "sha512-FJN5yd1LCbVvG3+fVkqfB42TOMtvbTqSYvkd4LWj4tFtF16uh2T76LkRJud6CXJChPynRqS6zsjAvLNAZKwp6g==",
       "requires": {
-        "cids": "~0.7.1",
-        "ipld-dag-pb": "^0.17.4",
         "json-stringify-deterministic": "^1.0.1",
-        "orbit-db-identity-provider": "~0.1.0",
-        "orbit-db-io": "~0.1.0",
+        "multihashing-async": "^2.0.1",
+        "orbit-db-identity-provider": "~0.3.1",
+        "orbit-db-io": "~0.2.0",
+        "p-do-whilst": "^1.1.0",
         "p-each-series": "^2.1.0",
-        "p-map": "^1.1.1",
-        "p-whilst": "^1.0.0"
-      },
-      "dependencies": {
-        "p-each-series": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
-          "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ=="
-        },
-        "p-map": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
-        }
-      }
-    },
-    "ipfs-mfs": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs/-/ipfs-mfs-0.11.7.tgz",
-      "integrity": "sha512-OA48yd+j9qAhRph5GfCRaLRjbZxIZ3QOAPSIHwndhWo1QLzFucgaCR+eWkn15tNPQGXL/sguExK2PEfGW1fSnA==",
-      "requires": {
-        "@hapi/boom": "^7.4.2",
-        "@hapi/joi": "^15.1.0",
-        "async-iterator-last": "^1.0.0",
-        "cids": "~0.7.1",
-        "debug": "^4.1.0",
-        "err-code": "^1.1.2",
-        "hamt-sharding": "~0.0.2",
-        "interface-datastore": "~0.6.0",
-        "ipfs-multipart": "~0.1.0",
-        "ipfs-unixfs": "~0.1.16",
-        "ipfs-unixfs-exporter": "~0.37.6",
-        "ipfs-unixfs-importer": "~0.39.9",
-        "ipld-dag-pb": "~0.17.2",
-        "joi-browser": "^13.4.0",
-        "mortice": "^1.2.1",
-        "multicodec": "~0.5.3",
-        "multihashes": "~0.4.14",
-        "once": "^1.4.0",
-        "promisify-es6": "^1.0.3",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "ipfs-multipart": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.1.tgz",
-      "integrity": "sha512-NAmCxgBkZ0usWXf8lMwYYEXvyzrqa65uy/1caVKm5yOKFoqXNrNOt4Ev99Pb+B0RMRqGSdfSvtnZM1cfhSSk2A==",
-      "requires": {
-        "@hapi/content": "^4.1.0",
-        "dicer": "~0.3.0"
+        "p-map": "^4.0.0",
+        "p-whilst": "^2.1.0"
       }
     },
     "ipfs-pubsub-1on1": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.6.tgz",
-      "integrity": "sha512-Sr44DX7mdhk6znR1+DlfUIB1qiu07T5SeOMJ9Okr62U+9MGl4YQaP8vOGrmLysIEKBryZQrku2vjfNj0nxBd1g==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-1on1/-/ipfs-pubsub-1on1-0.0.7.tgz",
+      "integrity": "sha512-j+3XefZ3xF7LlUo0cBm71aBEhVIvpwqNrtxhitkSWMkMwHUB6PfV8VSJuqUJ5lKg0t/Jo4IMDO5fdDInpUkU/Q==",
       "requires": {
-        "safe-buffer": "~5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
+        "safe-buffer": "~5.2.1"
       }
     },
     "ipfs-pubsub-peer-monitor": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.9.tgz",
-      "integrity": "sha512-EJpfNzM9HnS95qnoi0WajNT3i8AoLIkItSdQabNfopuiL/8Ky81MRy17S1wCIRrZEq2EpogG2DfZMJdvcp2I8g==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/ipfs-pubsub-peer-monitor/-/ipfs-pubsub-peer-monitor-0.0.10.tgz",
+      "integrity": "sha512-9bwI02MRruP0BDR8Mn4ujboLJhJ+6nm8X6JdGHdM9P1zlfy1MSJQNOXGhk2e1FInEZvFseFLYiCFuSS1BL7BnA==",
       "requires": {
-        "p-forever": "^1.0.1"
+        "p-forever": "^2.1.0"
       }
     },
     "ipfs-repo": {
-      "version": "0.26.6",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.26.6.tgz",
-      "integrity": "sha512-fcEV2y5N5tuI45zmoRQdDIN4bFj03xvxnZkXpblws4FMvPy0tkDZEtAdsZsmMnkbae2GDzwaKWZ6Dc3TPmzAZg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-6.0.3.tgz",
+      "integrity": "sha512-98dAkXAbX0JDGg2ML+h3usEZbQzghF/sCfAM/1Knh/VLdC7xcy34MqZQl+LyRTQEz872iUgk/TqqjkX2Sr2j2A==",
       "requires": {
-        "async": "^2.6.2",
-        "base32.js": "~0.1.0",
-        "bignumber.js": "^8.1.1",
-        "buffer": "^5.2.1",
-        "cids": "~0.7.0",
-        "datastore-core": "~0.6.0",
-        "datastore-fs": "~0.8.0",
-        "datastore-level": "~0.11.0",
+        "bignumber.js": "^9.0.0",
+        "bytes": "^3.1.0",
+        "cids": "^1.0.0",
+        "datastore-core": "^2.0.0",
+        "datastore-fs": "^2.0.0",
+        "datastore-level": "^2.0.0",
         "debug": "^4.1.0",
-        "dlv": "^1.1.2",
-        "interface-datastore": "~0.6.0",
-        "ipfs-block": "~0.8.1",
+        "err-code": "^2.0.0",
+        "interface-datastore": "^2.0.0",
+        "ipfs-repo-migrations": "^5.0.3",
+        "ipfs-utils": "^2.3.1",
+        "ipld-block": "^0.10.0",
+        "it-map": "^1.0.2",
+        "it-pushable": "^1.4.0",
+        "just-safe-get": "^2.0.0",
         "just-safe-set": "^2.1.0",
-        "multiaddr": "^6.0.6",
+        "multibase": "^3.0.0",
+        "p-queue": "^6.0.0",
         "proper-lockfile": "^4.0.0",
-        "pull-stream": "^3.6.9",
-        "sort-keys": "^2.0.0"
+        "sort-keys": "^4.0.0",
+        "uint8arrays": "^1.0.0"
       },
       "dependencies": {
-        "bignumber.js": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
         }
+      }
+    },
+    "ipfs-repo-migrations": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-5.0.5.tgz",
+      "integrity": "sha512-dbg9LY+f1MhKLCUTQ28z+TmS7+fC6dgZPJhsWpNXSSwicEgMjUssGMoaft9AjoOuOTISeF3WWVVKRqFpOvCxQg==",
+      "requires": {
+        "cbor": "^5.0.2",
+        "cids": "^1.0.0",
+        "datastore-core": "^2.0.0",
+        "debug": "^4.1.0",
+        "fnv1a": "^1.0.1",
+        "interface-datastore": "^2.0.0",
+        "ipld-dag-pb": "^0.20.0",
+        "it-length": "0.0.2",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "proper-lockfile": "^4.1.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.0.0",
+        "varint": "^5.0.0"
       }
     },
     "ipfs-unixfs": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.16.tgz",
-      "integrity": "sha512-TX9Dyu77MxpLzGh/LcQne95TofOyvOeW0oOi72aBMMcV1ItP3684e6NTG9KY1qzdrC+ZUR8kT7y18J058n8KXg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-2.0.3.tgz",
+      "integrity": "sha512-WpzG/VTqWBPh1cYW3CXk2naElYO3xU0rJnL3SBHbviZ6ZeHRadxR5k0v3/yxPuygs2AwBhaLqBNlV6uB6OCiQw==",
       "requires": {
-        "protons": "^1.0.1"
+        "err-code": "^2.0.0",
+        "protons": "^2.0.0"
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "0.37.7",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-0.37.7.tgz",
-      "integrity": "sha512-SZgaIy9MTFelKFnjzS6VAMKwVdukXej0vOKc+7IXVMoS2MRQ8nBOMnClqPD+2XXU49Z2T8fnZWKHzHs84zeuuw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-3.0.4.tgz",
+      "integrity": "sha512-e5rA97JeLaaCBOsuG62MJ2UJZQ3xgd8MoJpNotO37VDXRuE/X0/ny6N8AIxikZ8kHkNmCbclW+B5yQHcmqtRvA==",
       "requires": {
-        "async-iterator-last": "^1.0.0",
-        "cids": "~0.7.1",
-        "err-code": "^1.1.2",
-        "hamt-sharding": "~0.0.2",
-        "ipfs-unixfs": "~0.1.16",
-        "ipfs-unixfs-importer": "~0.39.11"
+        "cids": "^1.0.0",
+        "err-code": "^2.0.0",
+        "hamt-sharding": "^1.0.0",
+        "ipfs-unixfs": "^2.0.3",
+        "ipfs-utils": "^3.0.0",
+        "it-last": "^1.0.1",
+        "multihashing-async": "^2.0.0"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "0.39.11",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-0.39.11.tgz",
-      "integrity": "sha512-2eG6zCbMF3HPQE6TmBoq62XTMgVBqE4ja2gxpoIWOjOwVN6g/1LcX1vEqfPTLyFTG1lN3oad5xCblQLriXDUIQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-3.0.4.tgz",
+      "integrity": "sha512-2Lz1WSrmmMxBZzk99Uh1o76OZMWzkzgvSpcZcG8AdzpBDdjtsGWWED9FBuU31INT2dZk9Yszm8qxX3a8iYcXJg==",
       "requires": {
-        "async-iterator-all": "^1.0.0",
-        "async-iterator-batch": "~0.0.1",
-        "async-iterator-first": "^1.0.0",
-        "bl": "^3.0.0",
-        "deep-extend": "~0.6.0",
-        "err-code": "^1.1.2",
-        "hamt-sharding": "~0.0.2",
-        "ipfs-unixfs": "~0.1.16",
-        "ipld-dag-pb": "~0.17.2",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "rabin-wasm": "~0.0.4",
-        "superstruct": "~0.6.1"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
-          "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.2.1",
-            "err-code": "^1.1.2",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "bl": "^4.0.0",
+        "err-code": "^2.0.0",
+        "hamt-sharding": "^1.0.0",
+        "ipfs-unixfs": "^2.0.3",
+        "ipfs-utils": "^3.0.0",
+        "ipld-dag-pb": "^0.20.0",
+        "it-all": "^1.0.1",
+        "it-batch": "^1.0.3",
+        "it-first": "^1.0.1",
+        "it-parallel-batch": "^1.0.3",
+        "merge-options": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "rabin-wasm": "^0.1.1",
+        "uint8arrays": "^1.1.0"
       }
     },
     "ipfs-utils": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-0.0.4.tgz",
-      "integrity": "sha512-7cZf6aGj2FG3XJWhCNwn4mS93Q0GEWjtBZvEHqzgI43U2qzNDCyzfS1pei1Y5F+tw/zDJ5U4XG0G9reJxR53Ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-3.0.0.tgz",
+      "integrity": "sha512-qahDc+fghrM57sbySr2TeWjaVR/RH/YEB/hvdAjiTbjESeD87qZawrXwj+19Q2LtGmFGusKNLo5wExeuI5ZfDQ==",
       "requires": {
-        "buffer": "^5.2.1",
-        "is-buffer": "^2.0.3",
+        "abort-controller": "^3.0.0",
+        "any-signal": "^1.1.0",
+        "buffer": "^5.6.0",
+        "err-code": "^2.0.0",
+        "fs-extra": "^9.0.1",
         "is-electron": "^2.2.0",
-        "is-pull-stream": "0.0.0",
-        "is-stream": "^2.0.0",
-        "kind-of": "^6.0.2",
-        "readable-stream": "^3.4.0"
+        "iso-url": "^0.4.7",
+        "it-glob": "0.0.8",
+        "merge-options": "^2.0.0",
+        "nanoid": "^3.1.3",
+        "node-fetch": "^2.6.0",
+        "stream-to-it": "^0.2.0"
       }
     },
     "ipld": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.24.1.tgz",
-      "integrity": "sha512-Skc2yO0tzlYYFiSui/hUveA97/rpjSC5XU+AMrP1/ufdlqPdXRg9I+99pKsTCyoW7I/i1TOVh7y4B7c+J/AqjQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.27.1.tgz",
+      "integrity": "sha512-rX9TVFk9ZpMtjVdi74yaOgBcGRcz8NhGQHS4t/A4v/4UKp+nBWzDSMSAHpKXM1PGXYdlzYyIsfQMMoimQXVTxw==",
       "requires": {
-        "cids": "~0.7.0",
-        "ipfs-block": "~0.8.1",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.17.0",
-        "ipld-raw": "^4.0.0",
-        "merge-options": "^1.0.1",
-        "multicodec": "~0.5.1",
-        "promisify-es6": "^1.0.3",
-        "typical": "^5.0.0"
+        "cids": "^1.0.0",
+        "ipld-block": "^0.10.0",
+        "ipld-dag-cbor": "^0.17.0",
+        "ipld-dag-pb": "^0.20.0",
+        "ipld-raw": "^6.0.0",
+        "merge-options": "^2.0.0",
+        "multicodec": "^2.0.0",
+        "typical": "^6.0.0"
       }
     },
     "ipld-bitcoin": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.2.tgz",
-      "integrity": "sha512-cglP2KmfpQK6UWR6Yu4+F2Aj8z5m3z/ng4Bq2FV9rxASGSQn1nmVRFQu39j2lYcEUrvPPc+HRsDz1Ppvd6xODQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.4.0.tgz",
+      "integrity": "sha512-SRcNRMvdeIKlCCMymqas5ZX9tVjAZ/cid2LPd0vWrLtwc1r4liWvHAxbaU/fJa8Xo6neYWuS/XIqaE/yzMAhRw==",
       "requires": {
         "bitcoinjs-lib": "^5.0.0",
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "multicodec": "^1.0.0",
-        "multihashes": "^1.0.1",
-        "multihashing-async": "^1.0.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "err-code": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.0",
+        "multihashing-async": "^2.0.0",
+        "uint8arrays": "^1.0.0"
+      }
+    },
+    "ipld-block": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.10.1.tgz",
+      "integrity": "sha512-lPMfW9tA2hVZw9hdO/YSppTxFmA0+5zxcefBOlCTOn+12RLyy+pdepKMbQw8u0KESFu3pYVmabNRWuFGcgHLLw==",
+      "requires": {
+        "cids": "^1.0.0",
+        "class-is": "^1.1.0"
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.3.tgz",
-      "integrity": "sha512-m23nG7ZyoVFnkK55/bLAErc7EfiMgaEQlqHWDTGzPI+O5r6bPfp+qbL5zTVSIT8tpbHmu174dwerVtLoVgeVyA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.17.0.tgz",
+      "integrity": "sha512-YprSTQClJQUyC+RhbWrVXhg7ysII5R/jrmZZ4en4n9Mav+MRbntAW699zd1PHRLB71lNCJbxABE2Uc9QU2Ka7g==",
       "requires": {
         "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
+        "cids": "^1.0.0",
         "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "err-code": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-dag-pb": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.17.4.tgz",
-      "integrity": "sha512-YwCxETEMuXVspOKOhjIOHJvKvB/OZfCDkpSFiYBQN2/JQjM9y/RFCYzIQGm0wg7dCFLrhvfjAZLTSaKs65jzWA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.20.0.tgz",
+      "integrity": "sha512-zfM0EdaolqNjAxIrtpuGKvXxWk5YtH9jKinBuQGTcngOsWFQhyybGCTJHGNGGtRjHNJi2hz5Udy/8pzv4kcKyg==",
       "requires": {
-        "cids": "~0.7.0",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "multicodec": "~0.5.1",
-        "multihashing-async": "~0.7.0",
-        "protons": "^1.0.1",
-        "stable": "~0.1.8"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
-          "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.2.1",
-            "err-code": "^1.1.2",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0",
+        "protons": "^2.0.0",
+        "reset": "^0.1.0",
+        "run": "^1.4.0",
+        "stable": "^0.1.8",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-ethereum": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.2.tgz",
-      "integrity": "sha512-0uShqn7PcCgWca7lkn8WE8sS8GVDxoi7+juiSLw2MApx+r11hPBjiMDKy0SFZoyXMRYPZA6Xh1WTqzH8UM2eHA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-5.0.1.tgz",
+      "integrity": "sha512-M0n4z4y0LwsBKIvQev8xHOfxwjwR+jl6ot8z2ujScE6MX+inhojw2/vjvoWIk4N7oleNf3sg4ZxBzdttulvPTA==",
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
+        "cids": "^1.0.0",
         "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "^2.2.1",
         "ethereumjs-tx": "^2.1.1",
         "merkle-patricia-tree": "^3.0.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "^1.0.1",
-        "multihashing-async": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "multihashing-async": "^2.0.0",
         "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "err-code": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
       }
     },
     "ipld-git": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.3.tgz",
-      "integrity": "sha512-ffJgkGFb7VnTh8AOZNu19de1pXecbInJ62iEfL1ydn330tgwWtSMI2ny2EXGuOg1LvR9DF87Shz92CdtW4zYTw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.6.1.tgz",
+      "integrity": "sha512-HjKjmMX8vIEMk+isMBaU0/g+xi6LZOQHQ7oFaQ15wUUYLWe5rwkpdr8/3GqHEt3hKdEeWDCX2FqrmQsT9lrQFA==",
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "^0.8.3",
-        "multicodec": "^1.0.2",
-        "multihashing-async": "^1.0.0",
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
         "smart-buffer": "^4.1.0",
-        "strftime": "^0.10.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          }
-        },
-        "err-code": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
-          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "strftime": "^0.10.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "ipld-raw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
-      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-6.0.0.tgz",
+      "integrity": "sha512-UK7fjncAzs59iu/o2kwYtb8jgTtW6B+cNWIiNpAJkfRwqoMk1xD/6i25ktzwe4qO8gQgoR9RxA5ibC23nq8BLg==",
       "requires": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "dependencies": {
-        "err-code": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
-        },
-        "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashing-async": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
-          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.4.3",
-            "err-code": "^2.0.0",
-            "js-sha3": "^0.8.0",
-            "multihashes": "^1.0.1",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.0"
       }
     },
     "ipld-zcash": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.3.0.tgz",
-      "integrity": "sha512-9BTVBi3dhF1ZzFrWUqewrrBj0U1seG87/m4PJ1K44DylsX13r6eZP+yva6U+22pmhqGTS20yOZaS7clnAQWYOg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.5.0.tgz",
+      "integrity": "sha512-nBeyZ/g/hvP3FQl9IODe6mW+UoO10hQMb3k9elcAuwfromljE/rozoDMiMYagZAm03dkSHsk/YSeEWdWqRKaPQ==",
       "requires": {
-        "cids": "~0.7.0",
-        "multicodec": "~0.5.1",
-        "multihashes": "~0.4.12",
-        "multihashing-async": "~0.7.0",
-        "zcash-bitcore-lib": "~0.13.20-rc3"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.7.0.tgz",
-          "integrity": "sha512-SCbfl3f+DzJh+/5piukga9ofIOxwfT05t8R4jfzZIJ88YE9zU9+l3K2X+XB19MYyxqvyK9UJRNWbmQpZqQlbRA==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "buffer": "^5.2.1",
-            "err-code": "^1.1.2",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js-revisited": "^3.0.0"
-          }
-        }
+        "buffer": "^5.6.0",
+        "cids": "^1.0.0",
+        "multicodec": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "multihashing-async": "^2.0.0",
+        "zcash-block": "^2.0.0"
       }
     },
     "ipns": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.5.2.tgz",
-      "integrity": "sha512-SIC8J7+ptHRfkMB66yL+DVjrrFFSTOgtG67BVIVMOVQ0ctAONTDCjmvGCPNBuL2V3RYaee6gtuGjmJMAn46rJA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.8.0.tgz",
+      "integrity": "sha512-DbveKyLuiO6GgZ4lILxQ3h+27dV/5MPriDTDny3/WHEaCOYH8Gs64CRP5MBQPQcsnZ2Tg+YkjnUAKX/pWAwNhA==",
       "requires": {
-        "base32-encode": "^1.1.0",
         "debug": "^4.1.1",
-        "interface-datastore": "~0.6.0",
-        "libp2p-crypto": "~0.16.0",
-        "multihashes": "~0.4.14",
-        "peer-id": "~0.12.2",
-        "protons": "^1.0.1",
-        "timestamp-nano": "^1.0.0"
+        "err-code": "^2.0.0",
+        "interface-datastore": "^2.0.0",
+        "libp2p-crypto": "^0.18.0",
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
+        "timestamp-nano": "^1.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "is-buffer": {
@@ -4088,15 +4202,15 @@
       "resolved": "https://registry.npmjs.org/is-circular/-/is-circular-1.0.2.tgz",
       "integrity": "sha512-YttjnrswnUYRVJvxCvu8z+PGMUSzC2JttP0OEXezlAEdp3EXzhf7IZ3j0gRAybJBQupedIZFhY61Tga6E0qASA=="
     },
+    "is-domain-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-domain-name/-/is-domain-name-1.0.1.tgz",
+      "integrity": "sha1-9uszsUpJdUHcpYM1E31EZuDCDaE="
+    },
     "is-electron": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
       "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-fn": {
       "version": "1.0.0",
@@ -4104,9 +4218,9 @@
       "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
     },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-hex-prefixed": {
       "version": "1.0.0",
@@ -4114,12 +4228,12 @@
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
     "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
       }
     },
     "is-ip": {
@@ -4131,145 +4245,48 @@
       }
     },
     "is-ipfs": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.6.3.tgz",
-      "integrity": "sha512-HyRot1dvLcxImtDqPxAaY1miO6WsiP/z7Yxpg2qpaLWv5UdhAPtLvHJ4kMLM0w8GSl8AFsVF23PHe1LzuWrUlQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-2.0.0.tgz",
+      "integrity": "sha512-X4Cg/JO+h/ygBCrIQSMgicHRLo5QpB+i5tHLhFgGBksKi3zvX6ByFCshDxNBvcq4NFxF3coI2AaLqwzugNzKcw==",
       "requires": {
-        "bs58": "^4.0.1",
-        "cids": "~0.7.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "multibase": "~0.6.0",
-        "multihashes": "~0.4.13"
-      },
-      "dependencies": {
-        "mafmt": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-7.1.0.tgz",
-          "integrity": "sha512-vpeo9S+hepT3k2h5iFxzEHvvR0GPBx9uKaErmnRzYNcaKb03DgOArjEMlgG4a9LcuZZ89a3I8xbeto487n26eA==",
-          "requires": {
-            "multiaddr": "^7.3.0"
-          }
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "cids": {
-              "version": "0.8.3",
-              "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-              "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-              "requires": {
-                "buffer": "^5.6.0",
-                "class-is": "^1.1.0",
-                "multibase": "^1.0.0",
-                "multicodec": "^1.0.1",
-                "multihashes": "^1.0.1"
-              },
-              "dependencies": {
-                "multibase": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-                  "requires": {
-                    "base-x": "^3.0.8",
-                    "buffer": "^5.5.0"
-                  }
-                }
-              }
-            },
-            "multibase": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            },
-            "multihashes": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-              "requires": {
-                "buffer": "^5.6.0",
-                "multibase": "^1.0.1",
-                "varint": "^5.0.0"
-              },
-              "dependencies": {
-                "multibase": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-                  "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-                  "requires": {
-                    "base-x": "^3.0.8",
-                    "buffer": "^5.5.0"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        }
+        "cids": "^1.0.0",
+        "iso-url": "~0.4.7",
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
+        "uint8arrays": "^1.1.0"
       }
+    },
+    "is-node": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-node/-/is-node-1.0.2.tgz",
+      "integrity": "sha1-19ACdF733ru3R36YiVarCk/MtlM="
     },
     "is-npm": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
-      "integrity": "sha512-wsigDr1Kkschp2opC4G3yA6r9EgVA6NjRpWzIi9axXqeIaAATPRJc4uLujXe3Nd9uO8KoDyA4MD6aZSeXTADhA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
+      "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig=="
     },
     "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
     "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
     },
     "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-promise": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
       "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
-    },
-    "is-pull-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/is-pull-stream/-/is-pull-stream-0.0.0.tgz",
-      "integrity": "sha1-o7w9HG0wVRUcRr3m85nv7SFEDKk="
     },
     "is-stream": {
       "version": "2.0.0",
@@ -4287,14 +4304,19 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
     },
     "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "iso-constants": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/iso-constants/-/iso-constants-0.1.2.tgz",
+      "integrity": "sha512-OTCM5ZCQsHBCI4Wdu4tSxvDIkmDHd5EwJDps5mKqnQnWJSKlnwMs3EDZ4n3Fh1tmkWkDlyd2vCDbEYuPbyrUNQ=="
     },
     "iso-random-stream": {
       "version": "1.1.1",
@@ -4305,35 +4327,266 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "iso-stream-http": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/iso-stream-http/-/iso-stream-http-0.1.2.tgz",
-      "integrity": "sha512-oHEDNOysIMTNypbg2f1SlydqRBvjl4ZbSE9+0awVxnkx3K2stGTFwB/kpVqnB6UEfF8QD36kAjDwZvqyXBLMnQ==",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      }
-    },
     "iso-url": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
       "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
     },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    "it-all": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.4.tgz",
+      "integrity": "sha512-7K+gjHHzZ7t+bCkrtulYiow35k3UgqH7miC+iUa9RGiyDRXJ6hVDeFsDrnWrlscjrkLFOJRKHxNOke4FNoQnhw=="
+    },
+    "it-batch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.6.tgz",
+      "integrity": "sha512-W17vOT8tZTaPMw2NcXItBIAglBz3JxNdXE0+zgqPGMk6zrEb5YF+sAn+PuNed7R6Fsnp8IKDr1sa76GL8Cp52g=="
+    },
+    "it-buffer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/it-buffer/-/it-buffer-0.1.2.tgz",
+      "integrity": "sha512-NOJ3ogSNq3Y2c75ZDcPs9qlgitWyCkUQdmgqqMw+/LMmHZqwWQw7OBDodonz250nJ4EEBXkRQ+pIwz1sL9Zuyg==",
+      "requires": {
+        "bl": "^4.0.2",
+        "buffer": "^5.5.0"
+      }
+    },
+    "it-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/it-concat/-/it-concat-1.0.1.tgz",
+      "integrity": "sha512-ca7tnIqSpPycty9K+x08OwFj9kLSrsXgENn7ry2mNXlFlUkgEZe1/xvBjwnUlUEHvnITMj4Mq7ozPm1VaOm8FQ==",
+      "requires": {
+        "bl": "^4.0.0"
+      }
+    },
+    "it-drain": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.3.tgz",
+      "integrity": "sha512-KxwHBEpWW+0/EkGCOPR2MaHanvBW2A76tOC5CiitoJGLd8J56FxM6jJX3uow20v5qMidX5lnKgwH5oCIyYDszQ=="
+    },
+    "it-first": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.4.tgz",
+      "integrity": "sha512-L5ZB5k3Ol5ouAzLHo6fOCtByOy2lNjteNJpZLkE+VgmRt0MbC1ibmBW1AbOt6WzDx/QXFG5C8EEvY2nTXHg+Hw=="
+    },
+    "it-glob": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.8.tgz",
+      "integrity": "sha512-PmIAgb64aJPM6wwT1UTlNDAJnNgdGrvr0vRr3AYCngcUuq1KaAovuz0dQAmUkaXudDG3EQzc7OttuLW9DaL3YQ==",
+      "requires": {
+        "fs-extra": "^8.1.0",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
+    "it-goodbye": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-goodbye/-/it-goodbye-2.0.2.tgz",
+      "integrity": "sha512-k56lqArpxkIU0yyhnPhvnyOBpzRQn+4VEyd+dUBWhN5kvCgPBeC0XMuHiA71iU98sDpCrJrT/X+81ajT0AOQtQ==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "it-handshake": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-1.0.2.tgz",
+      "integrity": "sha512-uutOim5xF1eyDQD3u8qd3TxbWKwxqGMlbvacZsRsPdjO1BD9lnPTVci0jSMGsvMOu+5Y3W/QQ4hPQb87qPmPVQ==",
+      "requires": {
+        "it-pushable": "^1.4.0",
+        "it-reader": "^2.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "it-last": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.4.tgz",
+      "integrity": "sha512-h0aV43BaD+1nubAKwStWcda6vlbejPSTQKfOrQvyNrrceluWfoq8DrBXnL0PSz6RkyHSiVSHtAEaqUijYMPo8Q=="
+    },
+    "it-length": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-0.0.2.tgz",
+      "integrity": "sha512-4HJKhSx/hWg54DLzDSe4HYtjMqDVj2ZR8WBTjJuGqRTH342x2vt6h9KeycUgzNNfygSLJvGzFYtZ7Gw1Kez9Qg=="
+    },
+    "it-length-prefixed": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-3.1.0.tgz",
+      "integrity": "sha512-E5GwT6qfZEwh3/XThyYwgjKJ4/hxvTC9kdbj3gxXDeUDKtC7+K2T647sPeX7xDEWqunsnoQyvOrjoHPegaT3uw==",
+      "requires": {
+        "@types/bl": "^2.1.0",
+        "bl": "^4.0.2",
+        "buffer": "^5.5.0",
+        "varint": "^5.0.0"
+      }
+    },
+    "it-map": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.4.tgz",
+      "integrity": "sha512-LZgYdb89XMo8cFUp6jF0cn5j3gF7wcZnKRVFS3qHHn0bPB2rpToh2vIkTBKduZLZxRRjWx1VW/udd98x+j2ulg=="
+    },
+    "it-multipart": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-multipart/-/it-multipart-1.0.5.tgz",
+      "integrity": "sha512-HW0/ycdwqM1Xz1cwkBUwmU2HTxrJrUdVZBIgX5/fNzEjIgbnL3oZUysG2NeKNbIA0vt4wnqLK6fAps/nvQ0AbA==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "buffer-indexof": "^1.1.1",
+        "parse-headers": "^2.0.2"
+      }
+    },
+    "it-pair": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-1.0.0.tgz",
+      "integrity": "sha512-9raOiDu5OAuDOahtMtapKQDrQTxBfzlzrNcB6o7JARHkt+7Bb1dMkW/TpYdAjBJE77KH3e2zGzwpGUP9tXbLww==",
+      "requires": {
+        "get-iterator": "^1.0.2"
+      }
+    },
+    "it-parallel-batch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.6.tgz",
+      "integrity": "sha512-ym2o1bZHZAl2euR79ojKsvVJt77DGQrmSTgDf+g3ERF/Agp2+VI9VM3ikQ9T1BBdgbSIylPeatNGMIyZgz7J7g==",
+      "requires": {
+        "it-batch": "^1.0.6"
+      }
+    },
+    "it-pb-rpc": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/it-pb-rpc/-/it-pb-rpc-0.1.8.tgz",
+      "integrity": "sha512-YePzUUonithCTIdVKcOeQEn5mpipCg7ZoWsq7jfjXXtAS6gm6R7KzCe6YBV97i6bljU8hGllTG67FiGfweKNKg==",
+      "requires": {
+        "is-buffer": "^2.0.4",
+        "it-handshake": "^1.0.1",
+        "it-length-prefixed": "^3.0.1"
+      }
+    },
+    "it-peekable": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-0.0.1.tgz",
+      "integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw=="
+    },
+    "it-pipe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+      "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+    },
+    "it-protocol-buffers": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/it-protocol-buffers/-/it-protocol-buffers-0.2.1.tgz",
+      "integrity": "sha512-UbezSc9BZTw0DU7mFS6iG9PXeycJfTDJlFAlniI3x1CRrKeDP+IW6ERPAFskHI3O+wij18Mk7eHgDtFz4Zk65A==",
+      "requires": {
+        "it-buffer": "^0.1.1",
+        "it-length-prefixed": "^3.0.0"
+      }
+    },
+    "it-pushable": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-1.4.0.tgz",
+      "integrity": "sha512-W7251Tj88YBqUIEDWCwd3F8JettSbze+bBp5B3ASzz5tYWaLUI1VDNGbjllH1T6RJ71a5jUSTSt5vHjvuzwoFw==",
+      "requires": {
+        "fast-fifo": "^1.0.0"
+      }
+    },
+    "it-reader": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-2.1.0.tgz",
+      "integrity": "sha512-hSysqWTO9Tlwc5EGjVf8JYZzw0D2FsxD/g+eNNWrez9zODxWt6QlN6JAMmycK72Mv4jHEKEXoyzUN4FYGmJaZw==",
+      "requires": {
+        "bl": "^4.0.0"
+      }
+    },
+    "it-tar": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/it-tar/-/it-tar-1.2.2.tgz",
+      "integrity": "sha512-M8V4a9I+x/vwXTjqvixcEZbQZHjwDIb8iUQ+D4M2QbhAdNs3WKVSl+45u5/F2XFx6jYMFOGzMVlKNK/uONgNIA==",
+      "requires": {
+        "bl": "^4.0.0",
+        "buffer": "^5.4.3",
+        "iso-constants": "^0.1.2",
+        "it-concat": "^1.0.0",
+        "it-reader": "^2.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "it-to-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/it-to-buffer/-/it-to-buffer-1.0.4.tgz",
+      "integrity": "sha512-wycpGeAdQ8WH8eSBkMHN/HMNiQ0Y88XEXo6s6LGJbQZjf9K7ppVzUfCXn7OnxFfUPN0HTWZr+uhthwtrwMTTfw==",
+      "requires": {
+        "buffer": "^5.5.0"
+      }
+    },
+    "it-to-stream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.2.tgz",
+      "integrity": "sha512-DTB5TJRZG3untmZehcaFN0kGWl2bNv7tnJRgQHAO9QEt8jfvVRrebZtnD5NZd4SCj4WVPjl0LSrugNWE/UaZRQ==",
+      "requires": {
+        "buffer": "^5.6.0",
+        "fast-fifo": "^1.0.0",
+        "get-iterator": "^1.0.2",
+        "p-defer": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "it-ws": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-3.0.2.tgz",
+      "integrity": "sha512-INZhCXNjd5Xr7mYWtNZQb9y5i6XIsf4CKD4XUXeCD3tbaoIya1bPVtJNP1lN5UVGo6Ql9rAn3WVre/8IKtKShw==",
+      "requires": {
+        "buffer": "^5.6.0",
+        "event-iterator": "^2.0.0",
+        "relative-url": "^1.0.2",
+        "ws": "^7.3.1"
+      }
+    },
+    "iterable-ndjson": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iterable-ndjson/-/iterable-ndjson-1.1.0.tgz",
+      "integrity": "sha512-OOp1Lb0o3k5MkXHx1YaIY5Z0ELosZfTnBaas9f8opJVcZGBIONA2zY/6CYE+LKkqrSDooIneZbrBGgOZnHPkrg==",
+      "requires": {
+        "string_decoder": "^1.2.0"
+      }
     },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
-    "joi-browser": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/joi-browser/-/joi-browser-13.4.0.tgz",
-      "integrity": "sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ=="
+    "joi": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.1.tgz",
+      "integrity": "sha512-YT3/4Ln+5YRpacdmfEfrrKh50/kkgX3LgBltjqnlMPIYiZ4hxXZuVJcxmsvxsdeHg9soZfE3qXxHC2tMpCCBOA==",
+      "requires": {
+        "@hapi/address": "^4.1.0",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
     },
     "joycon": {
       "version": "2.2.5",
@@ -4365,11 +4618,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.1.tgz",
       "integrity": "sha512-9Fg0OY3uyzozpvJ8TVbUk09PjzhT7O2Q5kEe30g6OrKhbA/Is92igcx0XDDX7E3yAwnIlUcYLRl+ZkVrBYVP7A=="
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
     "json-text-sequence": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
@@ -4378,25 +4626,71 @@
         "delimit-stream": "0.1.0"
       }
     },
+    "jsondiffpatch": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.4.1.tgz",
+      "integrity": "sha512-t0etAxTUk1w5MYdNOkZBZ8rvYYN5iL+2dHCCx/DpkFm/bW28M6y5nUS83D4XdZiHy35Fpaw6LBb+F88fHZnVCw==",
+      "requires": {
+        "chalk": "^2.3.0",
+        "diff-match-patch": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        }
+      }
+    },
+    "jsonfile": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^1.0.0"
+      }
+    },
     "just-debounce-it": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-1.1.0.tgz",
       "integrity": "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg=="
     },
-    "just-flatten-it": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/just-flatten-it/-/just-flatten-it-2.1.0.tgz",
-      "integrity": "sha512-mX3NUt/LF6EzohLJZXhywCwz2zqdhx6wVkEu6UfUx00lVQlSB6SBV1O+/Le15NfsimrWRD82H69ZkSVQZffhmw=="
+    "just-extend": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
+      "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA=="
     },
-    "just-kebab-case": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-kebab-case/-/just-kebab-case-1.1.0.tgz",
-      "integrity": "sha512-QkuwuBMQ9BQHMUEkAtIA4INLrkmnnveqlFB1oFi09gbU0wBdZo6tTnyxNWMR84zHxBuwK7GLAwqN8nrvVxOLTA=="
-    },
-    "just-map-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/just-map-keys/-/just-map-keys-1.1.0.tgz",
-      "integrity": "sha512-oNKi+4y7fr8lXnhKYpBbCkiwHRVkAnx0VDkCeTDtKKMzGr1Lz1Yym+RSieKUTKim68emC5Yxrb4YmiF9STDO+g=="
+    "just-safe-get": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/just-safe-get/-/just-safe-get-2.0.0.tgz",
+      "integrity": "sha512-OBUeNXA7efFIGh0hSLW4nxrOtFWfmjoc3T8B5oixm3b+D7SZN10VKwORUEk4oDeBaR/sqkDMxXb0gE0DRYreEA=="
     },
     "just-safe-set": {
       "version": "2.1.0",
@@ -4418,13 +4712,6 @@
       "requires": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
-      },
-      "dependencies": {
-        "node-gyp-build": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-          "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
-        }
       }
     },
     "keypair": {
@@ -4440,35 +4727,6 @@
         "json-buffer": "3.0.0"
       }
     },
-    "kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-    },
-    "latency-monitor": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/latency-monitor/-/latency-monitor-0.2.1.tgz",
-      "integrity": "sha1-QEPV8j3obiv872ztSjtbki4d1+0=",
-      "requires": {
-        "debug": "^2.6.0",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -4477,14 +4735,15 @@
         "package-json": "^6.3.0"
       }
     },
-    "length-prefixed-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-2.0.0.tgz",
-      "integrity": "sha512-dvjTuWTKWe0oEznQcG6a9osfiYknCs7DEFJMP88n9Y581IFhYh1sZIgAFcuDOojKB0G7ftPreKhh4D0kh/VPjQ==",
+    "level": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
+      "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "varint": "^5.0.0"
+        "level-js": "^4.0.0",
+        "level-packager": "^5.0.0",
+        "leveldown": "^5.0.0",
+        "opencollective-postinstall": "^2.0.0"
       }
     },
     "level-codec": {
@@ -4519,23 +4778,15 @@
       }
     },
     "level-js": {
-      "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-      "from": "github:timkuijsten/level.js#idbunwrapper",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.2.tgz",
+      "integrity": "sha512-PeGjZsyMG4O89KHiez1zoMJxStnkM+oBIqgACjoo5PJqFiSUUm3GNod/KcbqN5ktyZa8jkG7I1T0P2u6HN9lIg==",
       "requires": {
-        "abstract-leveldown": "~2.4.1",
-        "idb-readable-stream": "0.0.4",
+        "abstract-leveldown": "~6.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "^2.0.3",
         "ltgt": "^2.1.2",
-        "xtend": "^4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
-          "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        }
+        "typedarray-to-buffer": "~3.1.5"
       }
     },
     "level-mem": {
@@ -4545,48 +4796,6 @@
       "requires": {
         "level-packager": "~4.0.0",
         "memdown": "~3.0.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz",
-          "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "immediate": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-        },
-        "memdown": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-          "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
-          "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "functional-red-black-tree": "~1.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
-      }
-    },
-    "level-packager": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
-      "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
-      "requires": {
-        "encoding-down": "~5.0.0",
-        "levelup": "^3.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -4618,6 +4827,11 @@
             "xtend": "^4.0.1"
           }
         },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
         "level-iterator-stream": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-3.0.1.tgz",
@@ -4626,6 +4840,15 @@
             "inherits": "^2.0.1",
             "readable-stream": "^2.3.6",
             "xtend": "^4.0.0"
+          }
+        },
+        "level-packager": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-4.0.1.tgz",
+          "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
+          "requires": {
+            "encoding-down": "~5.0.0",
+            "levelup": "^3.0.0"
           }
         },
         "levelup": {
@@ -4637,6 +4860,19 @@
             "level-errors": "~2.0.0",
             "level-iterator-stream": "~3.0.0",
             "xtend": "~4.0.0"
+          }
+        },
+        "memdown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
+          "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
+          "requires": {
+            "abstract-leveldown": "~5.0.0",
+            "functional-red-black-tree": "~1.0.1",
+            "immediate": "~3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
           }
         },
         "readable-stream": {
@@ -4668,6 +4904,15 @@
         }
       }
     },
+    "level-packager": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+      "requires": {
+        "encoding-down": "^6.3.0",
+        "levelup": "^4.3.2"
+      }
+    },
     "level-supports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
@@ -4685,11 +4930,6 @@
         "xtend": "~2.1.1"
       },
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
@@ -4737,6 +4977,11 @@
             "level-supports": "~1.0.0",
             "xtend": "~4.0.0"
           }
+        },
+        "node-gyp-build": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+          "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
         }
       }
     },
@@ -4758,105 +5003,136 @@
       "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
     },
     "libp2p": {
-      "version": "0.25.6",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.25.6.tgz",
-      "integrity": "sha512-9K4Blh39qX3r1YdPoGBZX4PxjBFMqQ3i3pkt0SK1q3D0hApyCpCyH/eHXlR+Uh5dBlr1KIoQC8bbH8vF9fMNBA==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.29.0.tgz",
+      "integrity": "sha512-eALoJ0vpsonRwzLpdPY2/272RIl2MImIg2QToqLb+wBChcSQFB4U/r3LU8rZqEaDfRNupOBG/rx67gJTWC0h2Q==",
       "requires": {
-        "async": "^2.6.2",
+        "abort-controller": "^3.0.0",
+        "aggregate-error": "^3.0.1",
+        "any-signal": "^1.1.0",
+        "bignumber.js": "^9.0.0",
+        "class-is": "^1.1.0",
         "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "fsm-event": "^2.1.0",
-        "libp2p-connection-manager": "^0.1.0",
-        "libp2p-floodsub": "^0.16.1",
-        "libp2p-ping": "^0.8.5",
-        "libp2p-switch": "^0.42.12",
-        "libp2p-websockets": "^0.12.2",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.1.0",
-        "once": "^1.4.0",
-        "peer-book": "^0.9.1",
-        "peer-id": "^0.12.2",
-        "peer-info": "^0.15.1",
-        "superstruct": "^0.6.0"
+        "err-code": "^2.0.0",
+        "events": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "interface-datastore": "^2.0.0",
+        "ipfs-utils": "^2.2.0",
+        "it-all": "^1.0.1",
+        "it-buffer": "^0.1.2",
+        "it-handshake": "^1.0.1",
+        "it-length-prefixed": "^3.0.1",
+        "it-pipe": "^1.1.0",
+        "it-protocol-buffers": "^0.2.0",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-interfaces": "^0.5.1",
+        "libp2p-utils": "^0.2.0",
+        "mafmt": "^8.0.0",
+        "merge-options": "^2.0.0",
+        "moving-average": "^1.0.0",
+        "multiaddr": "^8.0.0",
+        "multicodec": "^2.0.0",
+        "multistream-select": "^1.0.0",
+        "mutable-proxy": "^1.0.0",
+        "node-forge": "^0.9.1",
+        "p-any": "^3.0.0",
+        "p-fifo": "^1.0.0",
+        "p-settle": "^4.0.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
+        "retimer": "^2.0.0",
+        "sanitize-filename": "^1.6.3",
+        "streaming-iterables": "^5.0.2",
+        "timeout-abort-controller": "^1.1.1",
+        "varint": "^5.0.0",
+        "xsalsa20": "^1.0.2"
+      },
+      "dependencies": {
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        },
+        "libp2p-interfaces": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
+          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        }
       }
     },
     "libp2p-bootstrap": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.9.7.tgz",
-      "integrity": "sha512-GuuYoTh0UBBlph0WuuiewtDZqfYsXmhSdX+JLMzGY6uMuK5aLr7gCa++2zVyBoOIgn0yTq2F6n4vKaWoK9Hi0w==",
-      "requires": {
-        "async": "^2.6.1",
-        "debug": "^4.1.1",
-        "mafmt": "^6.0.4",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1"
-      }
-    },
-    "libp2p-circuit": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.3.7.tgz",
-      "integrity": "sha512-Z14T3D1YYE1W2k9QtheyxzfwGpEi4Tk4gDofSmAhKqlfCQcctNvKdv0udgjnwzZjXRBtAmNzVJfxZ2WagtZotA==",
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.0.6",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "protons": "^1.0.1",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.2",
-        "pull-pair": "^1.1.0",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "libp2p-connection-manager": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libp2p-connection-manager/-/libp2p-connection-manager-0.1.0.tgz",
-      "integrity": "sha512-Md5UERlkD+KUsdUQRJE+B+UBq/KwOTo650z8Bl0zEfKjfnv/yMeFhucnf14suYBnzIIdGsckYn66xbeki31BLw==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.12.1.tgz",
+      "integrity": "sha512-atHXxfxE8isHb+XKHsJ5UgFMteqfi0Xal94h+2EAJmobXcIq1mBMUeIgmkHMsaZZNwJwQxq6MKFthJngWJ8vEw==",
       "requires": {
         "debug": "^4.1.1",
-        "latency-monitor": "~0.2.1"
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "peer-id": "^0.14.0"
       }
     },
     "libp2p-crypto": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.3.tgz",
-      "integrity": "sha512-ro7/5Tu+f8p2+qDS1JrROnO++nNaAaBFs+VVXVHLuTMnbnMASu1eUtSlWPk1uOwikAlBFTvfqe5J1bK6Bpq6Pg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.18.0.tgz",
+      "integrity": "sha512-zNMHDwf2J4t1LRjrBPMiSa4+14u0SfZRu66FyIVZtOnBGo3V/8imbJsOp8RPT8IgeHRN7EVIUt9lp8dcgXHMOw==",
       "requires": {
-        "asmcrypto.js": "^2.3.2",
-        "asn1.js": "^5.0.1",
-        "async": "^2.6.1",
-        "bn.js": "^4.11.8",
-        "browserify-aes": "^1.2.0",
-        "bs58": "^4.0.1",
+        "err-code": "^2.0.0",
+        "is-typedarray": "^1.0.0",
         "iso-random-stream": "^1.1.0",
         "keypair": "^1.0.1",
-        "libp2p-crypto-secp256k1": "~0.3.0",
-        "multihashing-async": "~0.5.1",
-        "node-forge": "~0.9.1",
+        "multibase": "^3.0.0",
+        "multicodec": "^2.0.0",
+        "multihashing-async": "^2.0.1",
+        "node-forge": "^0.9.1",
         "pem-jwk": "^2.0.0",
-        "protons": "^1.0.1",
-        "rsa-pem-to-jwk": "^1.1.3",
-        "tweetnacl": "^1.0.0",
-        "ursa-optional": "~0.10.0"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
+        "protons": "^2.0.0",
+        "secp256k1": "^4.0.0",
+        "uint8arrays": "^1.1.0",
+        "ursa-optional": "^0.10.1"
       }
     },
     "libp2p-crypto-secp256k1": {
@@ -4870,365 +5146,8 @@
         "nodeify": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "secp256k1": "^3.6.2"
-      }
-    },
-    "libp2p-floodsub": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.16.1.tgz",
-      "integrity": "sha512-3Y+BMwlgit5LGKFUwEn5hNH9+WvhK4mkSEKe7mu0xtQ0KmFvwUpYt+UO/By1iZRpYDyEhQ8rya0ZJtYcqFkxvg==",
-      "requires": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "debug": "^4.1.1",
-        "length-prefixed-stream": "^2.0.0",
-        "libp2p-crypto": "~0.16.1",
-        "libp2p-pubsub": "~0.1.0",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.2",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "libp2p-identify": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.7.6.tgz",
-      "integrity": "sha512-QleYqI6f8ah6G6sQU9uaIa9FVOtyp6LtiqopfjrmAIO5Oz22Zw+dpT7FcEXvYP7kL036Es2vzZm0js0pOWw1MA==",
-      "requires": {
-        "multiaddr": "^6.0.4",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "libp2p-kad-dht": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.15.4.tgz",
-      "integrity": "sha512-0hMYGpk2xra0j+yqYuPauhLjpIsvy4ZDcPhY692juVhiTls4WKfQs3XMlC0s2Q0VhUrDsaS3cgpFZTyJYgn++Q==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "async": "^2.6.2",
-        "base32.js": "~0.1.0",
-        "callbackify": "^1.1.0",
-        "chai-checkmark": "^1.0.1",
-        "cids": "~0.7.0",
-        "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "hashlru": "^2.3.0",
-        "heap": "~0.2.6",
-        "interface-datastore": "~0.6.0",
-        "k-bucket": "^5.0.0",
-        "libp2p-crypto": "~0.16.1",
-        "libp2p-record": "~0.6.2",
-        "merge-options": "^1.0.1",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.5.2",
-        "p-queue": "^6.0.0",
-        "p-times": "^2.1.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "priorityqueue": "~0.2.1",
-        "promise-to-callback": "^1.0.0",
-        "promisify-es6": "^1.0.3",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.2",
-        "pull-stream": "^3.6.9",
-        "pull-stream-to-async-iterator": "^1.0.1",
-        "varint": "^5.0.0",
-        "xor-distance": "^2.0.0"
       },
       "dependencies": {
-        "multihashing-async": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
-    "libp2p-keychain": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.4.2.tgz",
-      "integrity": "sha512-/rhjUQM9DDL4gfP7bdkqfnXYl4JlDrsnCMrPGmWmtnnLk9LdaIcJ+93IOKpB7B2LE7Td+1+JZRys2JjTBs21nQ==",
-      "requires": {
-        "async": "^2.6.2",
-        "err-code": "^1.1.2",
-        "interface-datastore": "~0.6.0",
-        "libp2p-crypto": "~0.16.1",
-        "merge-options": "^1.0.1",
-        "node-forge": "~0.7.6",
-        "pull-stream": "^3.6.9",
-        "sanitize-filename": "^1.6.1"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.7.6",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-          "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
-        }
-      }
-    },
-    "libp2p-mdns": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.12.3.tgz",
-      "integrity": "sha512-jJvmRc2hd8inWRpWBGwJnu4t4Qxg/5LCMwivwTp3Rqf/NRHdqAuArT5VroFdgIiay9pQ9LjrA2zXIpT2ZLDusA==",
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^4.1.1",
-        "libp2p-tcp": "~0.13.0",
-        "multiaddr": "^6.0.6",
-        "multicast-dns": "^7.2.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1"
-      }
-    },
-    "libp2p-ping": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.5.tgz",
-      "integrity": "sha512-BzCN3+jp1SvJQZlXq2G3TMkyK5UOOf3JO+CZMnaUEHYlRgQf2zShYta5XU2IGx0EJA/23iCdCL+LjBP/DOvbkQ==",
-      "requires": {
-        "libp2p-crypto": "~0.16.0",
-        "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "libp2p-pubsub": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.1.0.tgz",
-      "integrity": "sha512-oppDCIZLmqODAgt1r625yO0j9wy7auro7B6/5bw2WN5ctqTsG791dn3SGVRLV8Dvd7uSfMlOaZ/Bkw8jle0Ytg==",
-      "requires": {
-        "async": "^2.6.2",
-        "bs58": "^4.0.1",
-        "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "length-prefixed-stream": "^2.0.0",
-        "libp2p-crypto": "~0.16.1",
-        "protons": "^1.0.1",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "time-cache": "~0.3.0"
-      }
-    },
-    "libp2p-record": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.3.tgz",
-      "integrity": "sha512-FUJ69hb20SETlKmXkdlG7AJPPZmaRrzNBR2d4aTRVYcR2LPWzamGg6UeDEP5DAHXUqMhtEP38oEKcrLn07kaOw==",
-      "requires": {
-        "async": "^2.6.2",
-        "buffer-split": "^1.0.0",
-        "err-code": "^1.1.2",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.6.0",
-        "protons": "^1.0.1"
-      }
-    },
-    "libp2p-secio": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.11.1.tgz",
-      "integrity": "sha512-PMVlLutZcCpaNMQZbsbADUR6BWAFuB7ap8fc006YFj3uRQpq8HEVW6DsYlNVG6QQm9JMdvaitfgLTaDFqw5bVg==",
-      "requires": {
-        "async": "^2.6.1",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.16.0",
-        "multihashing-async": "~0.5.2",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "protons": "^1.0.1",
-        "pull-defer": "~0.2.3",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.1",
-        "pull-stream": "^3.6.9"
-      },
-      "dependencies": {
-        "multihashing-async": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
-          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
-          "requires": {
-            "blakejs": "^1.1.0",
-            "js-sha3": "~0.8.0",
-            "multihashes": "~0.4.13",
-            "murmurhash3js": "^3.0.1",
-            "nodeify": "^1.0.1"
-          }
-        }
-      }
-    },
-    "libp2p-switch": {
-      "version": "0.42.12",
-      "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.42.12.tgz",
-      "integrity": "sha512-aNjJQpP9kSClXXKIliSqIowIoxAy0JQ8hnw6BoqOHUIG9Eov4GVyuOdU6lQKl1ym4uKMsnF2G49qpZJ47O01XA==",
-      "requires": {
-        "async": "^2.6.2",
-        "bignumber.js": "^8.1.1",
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "fsm-event": "^2.1.0",
-        "hashlru": "^2.3.0",
-        "interface-connection": "~0.3.3",
-        "libp2p-circuit": "~0.3.6",
-        "libp2p-identify": "~0.7.6",
-        "moving-average": "^1.0.0",
-        "multiaddr": "^6.0.6",
-        "multistream-select": "~0.14.4",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "pull-stream": "^3.6.9",
-        "retimer": "^2.0.0"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
-          "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
-        }
-      }
-    },
-    "libp2p-tcp": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.2.tgz",
-      "integrity": "sha512-TvHLCn25m+UIH+hXTuy8xJDU/Kxj8EEEgWzhWUImsrb/YsYFywjbuv8YCAYtTUMIzyT2DnTtM+xzPxccg/sytw==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "ip-address": "^6.1.0",
-        "lodash.includes": "^4.3.0",
-        "lodash.isfunction": "^3.0.9",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.1.0",
-        "once": "^1.4.0",
-        "stream-to-pull-stream": "^1.7.3"
-      }
-    },
-    "libp2p-webrtc-star": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.16.1.tgz",
-      "integrity": "sha512-TLQ/Qhfx367kETt2pz2ejzVMB01PQjkBqxP+p+PD84N+JuFg3HVQw8jwXdiXexg/gKNMH+WwqVeWiKv/mVrCNA==",
-      "requires": {
-        "@hapi/hapi": "^18.3.1",
-        "@hapi/inert": "^5.2.0",
-        "async": "^2.6.2",
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "epimetheus": "^1.0.92",
-        "interface-connection": "~0.3.3",
-        "mafmt": "^6.0.7",
-        "minimist": "^1.2.0",
-        "multiaddr": "^6.0.6",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "pull-stream": "^3.6.9",
-        "simple-peer": "^9.3.0",
-        "socket.io": "^2.1.1",
-        "socket.io-client": "^2.1.1",
-        "stream-to-pull-stream": "^1.7.3",
-        "webrtcsupport": "github:ipfs/webrtcsupport"
-      }
-    },
-    "libp2p-websocket-star": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.10.2.tgz",
-      "integrity": "sha512-ccjMqy7lrKV6vbTdsm9XOZ+eWt01ZCS3hI2s+I+ZpglnPQNg8z+dGs+8rdl8/hU44Sq3EbmUw0gCxPB/2ZbPlg==",
-      "requires": {
-        "async": "^2.6.1",
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.16.0",
-        "mafmt": "^6.0.4",
-        "multiaddr": "^6.0.3",
-        "nanoid": "^2.0.0",
-        "once": "^1.4.0",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1",
-        "pull-stream": "^3.6.9",
-        "socket.io-client": "^2.1.1",
-        "socket.io-pull-stream": "~0.1.5"
-      }
-    },
-    "libp2p-websocket-star-multi": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/libp2p-websocket-star-multi/-/libp2p-websocket-star-multi-0.4.4.tgz",
-      "integrity": "sha512-+Cj9ghJkqlFTa34tWx0Mi0FZ7LGH4l2rCrgmINZsU/Szq+NbIPb5LFiaJEzyB6vGAOMjC+2J3Ei7luIvrgXzKg==",
-      "requires": {
-        "async": "^2.6.2",
-        "debug": "^4.1.1",
-        "libp2p-websocket-star": "~0.10.2",
-        "mafmt": "^6.0.7",
-        "multiaddr": "^6.0.6",
-        "once": "^1.4.0"
-      }
-    },
-    "libp2p-websockets": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.12.4.tgz",
-      "integrity": "sha512-wXrdFgBibvuD+b+s1KIvhlbzh/qCXSDBmzkoKUugftxV6tC5AhotbHW1JlcI726+U+z4k8ha3nEZd9PY64NLqQ==",
-      "requires": {
-        "class-is": "^1.1.0",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "mafmt": "^6.0.7",
-        "multiaddr-to-uri": "^5.0.0",
-        "pull-ws": "github:hugomrdias/pull-ws#fix/bundle-size"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multiaddr-to-uri": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-5.1.0.tgz",
-          "integrity": "sha512-rIlMLkw3yk3RJmf2hxYYzeqPXz4Vx7C4M/hg7BVWhmksDW0rDVNMEyoVb0H1A+sh3deHOh5EAFK87XcW+mFimA==",
-          "requires": {
-            "multiaddr": "^7.2.1"
-          }
-        },
         "multibase": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
@@ -5238,37 +5157,397 @@
             "buffer": "^5.5.0"
           }
         },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
           "requires": {
-            "buffer": "^5.6.0",
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
             "varint": "^5.0.0"
           }
         },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+        "multihashing-async": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
+          "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
           "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
+            "blakejs": "^1.1.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "secp256k1": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+          "requires": {
+            "bindings": "^1.5.0",
+            "bip66": "^1.1.5",
+            "bn.js": "^4.11.8",
+            "create-hash": "^1.2.0",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.5.2",
+            "nan": "^2.14.0",
+            "safe-buffer": "^5.1.2"
           }
         }
       }
+    },
+    "libp2p-delegated-content-routing": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.7.0.tgz",
+      "integrity": "sha512-eyh6ckCJvAuH+dSI6lKrZ6JLdxazpPUpd2NbRcgmgb6sfpTyFaxhqMa5FHz304mX2FsvE3pX91pTShcL9Aitjg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "it-all": "^1.0.0",
+        "multiaddr": "^8.0.0",
+        "p-defer": "^3.0.0",
+        "p-queue": "^6.2.1"
+      }
+    },
+    "libp2p-delegated-peer-routing": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.7.0.tgz",
+      "integrity": "sha512-bdSnCRts+AMlUv592ZITot+vels1UYQc4WMg8/y+gur1ifEE6GeGWnxneJyCuuzrrjmo2Svr4yY72kuMev+wVQ==",
+      "requires": {
+        "cids": "^1.0.0",
+        "debug": "^4.1.1",
+        "p-defer": "^3.0.0",
+        "p-queue": "^6.3.0",
+        "peer-id": "^0.14.0"
+      }
+    },
+    "libp2p-floodsub": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.23.1.tgz",
+      "integrity": "sha512-d5Hl055SV3bkJ2u+bsRp+iWBsg1rVq2CehW2TYq4zoIp/bCGQyY/oQF6NzqnysKloElgRACfWOa/oQBRaSZFng==",
+      "requires": {
+        "debug": "^4.1.1",
+        "libp2p-interfaces": "^0.5.1",
+        "time-cache": "^0.3.0",
+        "uint8arrays": "^1.1.0"
+      },
+      "dependencies": {
+        "libp2p-interfaces": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
+          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        }
+      }
+    },
+    "libp2p-gossipsub": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.6.1.tgz",
+      "integrity": "sha512-gwmRlS//Zz1nYuq4BfOsV3yg27i++uXihnteF5RztqRz6FqrRd0JsID32HtzD+LQ93PGTB457sxuOOpDvXLapQ==",
+      "requires": {
+        "@types/debug": "^4.1.5",
+        "debug": "^4.1.1",
+        "denque": "^1.4.1",
+        "err-code": "^2.0.0",
+        "it-pipe": "^1.0.1",
+        "libp2p-interfaces": "^0.5.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
+        "time-cache": "^0.3.0"
+      },
+      "dependencies": {
+        "libp2p-interfaces": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.5.1.tgz",
+          "integrity": "sha512-mqu8kN5KppDjRIzdOZqg7yEMwLJOxFGDpdXhvTq4obephTIusW4lLSunst7C5VVSN6UE0SSVliN0tHvyW8tpag==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "debug": "^4.1.1",
+            "delay": "^4.3.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-length-prefixed": "^3.1.0",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.1.0",
+            "it-pushable": "^1.4.0",
+            "libp2p-crypto": "^0.18.0",
+            "libp2p-tcp": "^0.15.0",
+            "multiaddr": "^8.0.0",
+            "multibase": "^3.0.0",
+            "p-defer": "^3.0.0",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.14.0",
+            "protons": "^2.0.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^5.0.2",
+            "uint8arrays": "^1.1.0"
+          }
+        }
+      }
+    },
+    "libp2p-interfaces": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.4.1.tgz",
+      "integrity": "sha512-LvoK21WtoRxmdLFWGGKMomK4SLXSqcyntoCQ254IOao/EOjis0Za09THENjK+pL1Lk84D1tXLwwK+8pT19EWDw==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "abortable-iterator": "^3.0.0",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "chai-checkmark": "^1.0.1",
+        "class-is": "^1.1.0",
+        "delay": "^4.3.0",
+        "detect-node": "^2.0.4",
+        "dirty-chai": "^2.0.1",
+        "err-code": "^2.0.0",
+        "it-goodbye": "^2.0.1",
+        "it-pair": "^1.0.0",
+        "it-pipe": "^1.1.0",
+        "libp2p-tcp": "^0.15.0",
+        "multiaddr": "^8.0.0",
+        "p-defer": "^3.0.0",
+        "p-limit": "^2.3.0",
+        "p-wait-for": "^3.1.0",
+        "peer-id": "^0.14.0",
+        "sinon": "^9.0.2",
+        "streaming-iterables": "^5.0.2"
+      }
+    },
+    "libp2p-kad-dht": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.20.1.tgz",
+      "integrity": "sha512-khffe6L6O6oU53LO8BrI3bULH4i6FLibvFEyV+7FAPXnFYhTKHa9TsIifkL/MEAfLI0hI9QN4NwMf0DpOLMvDA==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "async": "^2.6.2",
+        "base32.js": "~0.1.0",
+        "cids": "^1.0.0",
+        "debug": "^4.1.1",
+        "err-code": "^2.0.0",
+        "hashlru": "^2.3.0",
+        "heap": "~0.2.6",
+        "interface-datastore": "^2.0.0",
+        "it-length-prefixed": "^3.0.0",
+        "it-pipe": "^1.1.0",
+        "k-bucket": "^5.0.0",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-interfaces": "^0.4.0",
+        "libp2p-record": "^0.9.0",
+        "multiaddr": "^8.0.0",
+        "multihashing-async": "^2.0.1",
+        "p-filter": "^2.1.0",
+        "p-map": "^4.0.0",
+        "p-queue": "^6.2.1",
+        "p-timeout": "^3.2.0",
+        "p-times": "^3.0.0",
+        "peer-id": "^0.14.0",
+        "promise-to-callback": "^1.0.0",
+        "protons": "^2.0.0",
+        "streaming-iterables": "^5.0.2",
+        "uint8arrays": "^1.1.0",
+        "varint": "^5.0.0",
+        "xor-distance": "^2.0.0"
+      }
+    },
+    "libp2p-mdns": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.15.0.tgz",
+      "integrity": "sha512-wuILE+mwC6ww/0TMkR3k2h53D5Ma9TXpz0siacbsACcGukkS+mIpsvruaf9U1Uxe0F1aC8+Y+Vi5lP8C3YR9Lg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "multiaddr": "^8.0.0",
+        "multicast-dns": "^7.2.0",
+        "peer-id": "^0.14.0"
+      }
+    },
+    "libp2p-mplex": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/libp2p-mplex/-/libp2p-mplex-0.10.0.tgz",
+      "integrity": "sha512-q+zpo12ldm8E+AlnR/LK/j++MM8IkDHi/P19VMPWP07irXe1Pmy/lw6IrSqtDOD8KQc86ipib9d1PI3ALdN8vA==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "abortable-iterator": "^3.0.0",
+        "bl": "^4.0.0",
+        "debug": "^4.1.1",
+        "it-pipe": "^1.0.1",
+        "it-pushable": "^1.3.1",
+        "varint": "^5.0.0"
+      }
+    },
+    "libp2p-noise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-2.0.1.tgz",
+      "integrity": "sha512-Jhd/jirWL3qkqGqIC1P4SH+OYlmKFll6UjFVYdw7otBKnbmdBUTW2Lg75/L1+7dYKwitHKu5EWlAd3zPU36gfg==",
+      "requires": {
+        "bcrypto": "^5.2.0",
+        "buffer": "^5.4.3",
+        "debug": "^4.1.1",
+        "it-buffer": "^0.1.1",
+        "it-length-prefixed": "^3.0.0",
+        "it-pair": "^1.0.0",
+        "it-pb-rpc": "^0.1.8",
+        "it-pipe": "^1.1.0",
+        "libp2p-crypto": "^0.18.0",
+        "peer-id": "^0.14.0",
+        "protobufjs": "^6.10.1",
+        "uint8arrays": "^1.1.0"
+      }
+    },
+    "libp2p-record": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.9.0.tgz",
+      "integrity": "sha512-8FlhzP+UlXTYOR+9D8nYoGOIJ6S8XogKD625bqzHJbXJQyJNCNaW3tZPHqrQrvUW7o6GsAeyQAfCp5WLEH0FZg==",
+      "requires": {
+        "err-code": "^2.0.0",
+        "multihashes": "^3.0.1",
+        "multihashing-async": "^2.0.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.1.0"
+      }
+    },
+    "libp2p-secio": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.13.1.tgz",
+      "integrity": "sha512-1rJBqaCTeKAyA1BedfGCjG8SKB+fOqWXPJLklkaRBcdwmtoNdvCLuLt5So81Z/5sqrbETM1vAQRVdMpyTfPrKw==",
+      "requires": {
+        "bl": "^4.0.0",
+        "debug": "^4.1.1",
+        "it-length-prefixed": "^3.0.1",
+        "it-pair": "^1.0.0",
+        "it-pb-rpc": "^0.1.4",
+        "it-pipe": "^1.1.0",
+        "libp2p-crypto": "^0.18.0",
+        "libp2p-interfaces": "^0.4.0",
+        "multiaddr": "^8.0.0",
+        "multihashing-async": "^2.0.1",
+        "peer-id": "^0.14.0",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.1.0"
+      }
+    },
+    "libp2p-tcp": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.1.tgz",
+      "integrity": "sha512-alvgZ3lSNUyiz4vJOqvm6RpMQN9d17gSJa+VT+2pYLGf82o8pX3QvyhltMkBG7u9I+qZAkD6L27s8o0h38dpOg==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "debug": "^4.1.1",
+        "err-code": "^2.0.0",
+        "libp2p-utils": "^0.2.0",
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "stream-to-it": "^0.2.2"
+      }
+    },
+    "libp2p-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.2.0.tgz",
+      "integrity": "sha512-tZmqu27SULiIvfV+RZg5WOomxXIqM/SEd9FwKuirYTHHU1eet2bLzVQBhigatrdyQxebqi8GVnwbKmqdRElgCA==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "debug": "^4.1.1",
+        "err-code": "^2.0.3",
+        "ip-address": "^6.1.0",
+        "multiaddr": "^8.0.0"
+      }
+    },
+    "libp2p-webrtc-peer": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-10.0.1.tgz",
+      "integrity": "sha512-Qi/YVrSI5sjU+iBvr1iAjGrakIEvzCS8S76v4q43jjlDb6Wj+S4OnFLH/uRlt7eLXcx4vlaI6huMzYrUAoopMg==",
+      "requires": {
+        "debug": "^4.0.1",
+        "err-code": "^2.0.3",
+        "get-browser-rtc": "^1.0.0",
+        "queue-microtask": "^1.1.0",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "libp2p-webrtc-star": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.20.1.tgz",
+      "integrity": "sha512-VQNL24A3rN1/9U0fTO8MqUx3+6d99iz/HvPI3p+IzHb6MgBe7er+rgbvRep7uheZ2894IxiJI848Vs0ZNypn2w==",
+      "requires": {
+        "@hapi/hapi": "^20.0.0",
+        "@hapi/inert": "^6.0.2",
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "debug": "^4.1.1",
+        "err-code": "^2.0.0",
+        "ipfs-utils": "^3.0.0",
+        "it-pipe": "^1.0.1",
+        "libp2p-utils": "^0.2.0",
+        "libp2p-webrtc-peer": "^10.0.1",
+        "mafmt": "^8.0.0",
+        "menoetius": "0.0.2",
+        "minimist": "^1.2.0",
+        "multiaddr": "^8.0.0",
+        "p-defer": "^3.0.0",
+        "peer-id": "^0.14.0",
+        "prom-client": "^12.0.0",
+        "socket.io": "^2.3.0",
+        "socket.io-client": "^2.3.0",
+        "stream-to-it": "^0.2.2",
+        "streaming-iterables": "^5.0.2"
+      }
+    },
+    "libp2p-websockets": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.14.0.tgz",
+      "integrity": "sha512-UeI0uqw2xYXFhImJucewG7fuL6hOR2tnSwlSAAxilyK0Z3Yya+GeVkqy7Vufj9ax3EWFx6lPO8mC3uBl30TkpA==",
+      "requires": {
+        "abortable-iterator": "^3.0.0",
+        "class-is": "^1.1.0",
+        "debug": "^4.1.1",
+        "err-code": "^2.0.0",
+        "it-ws": "^3.0.0",
+        "libp2p-utils": "^0.2.0",
+        "mafmt": "^8.0.0",
+        "multiaddr": "^8.0.0",
+        "multiaddr-to-uri": "^6.0.0",
+        "p-timeout": "^3.2.0"
+      }
+    },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
     },
     "localstorage-down": {
       "version": "0.6.7",
@@ -5292,11 +5571,6 @@
             "xtend": "~3.0.0"
           }
         },
-        "buffer-from": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
-        },
         "xtend": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
@@ -5310,12 +5584,11 @@
       "integrity": "sha512-t9P8WB6DcVttbw/W4PIE8HOqum8Qlvx5SjR6oInwR9Uia0EEmyUeBh7S+weKByW+l/f45Bj4L/dgZikGFDM6ng=="
     },
     "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^4.1.0"
       }
     },
     "lodash": {
@@ -5328,20 +5601,10 @@
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
     },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isequalwith": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequalwith/-/lodash.isequalwith-4.4.0.tgz",
-      "integrity": "sha1-Jmcm3dUo+FTyH06pigZWBuD7xrA="
-    },
-    "lodash.isfunction": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.max": {
       "version": "4.0.1",
@@ -5378,11 +5641,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
-    "looper": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-      "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-    },
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -5410,19 +5668,26 @@
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
     },
     "mafmt": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-6.0.10.tgz",
-      "integrity": "sha512-FjHDnew6dW9lUu3eYwP0FvvJl9uvNbqfoJM+c1WJcSyutNEIlyu6v3f/rlPnD1cnmue38IjuHlhBdIh3btAiyw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-8.0.0.tgz",
+      "integrity": "sha512-MdaeaqZxjoYYWvlhr1GQ7sbsR3+L3s8QL0VtCuja+Iax3EhqAEgluSWPJezSDLyns7Ds4DGRyoq5+eIU7UDang==",
       "requires": {
-        "multiaddr": "^6.1.0"
+        "multiaddr": "^8.0.0"
       }
     },
     "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "requires": {
-        "pify": "^3.0.0"
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "md5.js": {
@@ -5463,13 +5728,36 @@
         }
       }
     },
-    "merge-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
-      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+    "menoetius": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/menoetius/-/menoetius-0.0.2.tgz",
+      "integrity": "sha512-7W0ayHMNgvEdFh+m3m29KA87nvT0JIGCXeSZa26fiSof+bwpg+olEjD8AAvtxZ3uhTcp2d+5r1dcV/KhR8PBVQ==",
       "requires": {
-        "is-plain-obj": "^1.1"
+        "prom-client": "^11.5.3"
+      },
+      "dependencies": {
+        "prom-client": {
+          "version": "11.5.3",
+          "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
+          "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+          "requires": {
+            "tdigest": "^0.1.1"
+          }
+        }
       }
+    },
+    "merge-options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-2.0.0.tgz",
+      "integrity": "sha512-S7xYIeWHl2ZUKF7SDeBhGg6rfv5bKxVBdk95s/I7wVF8d+hjLSztJ/B271cnUiF6CAFduEQ5Zn3HYwAjT16DlQ==",
+      "requires": {
+        "is-plain-obj": "^2.0.0"
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "merkle-lib": {
       "version": "2.0.10",
@@ -5503,6 +5791,11 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
           }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "level-ws": {
           "version": "1.0.0",
@@ -5552,6 +5845,15 @@
         }
       }
     },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      }
+    },
     "mime-db": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
@@ -5564,6 +5866,11 @@
       "requires": {
         "mime-db": "1.44.0"
       }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -5593,35 +5900,17 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
-    "mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "requires": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
-        }
-      }
-    },
     "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mortice": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/mortice/-/mortice-1.2.3.tgz",
-      "integrity": "sha512-m285eSxSrbNieKgWWzGSbWO2oSoFHb2fdZX306afMVJ8p8boeAmUW5hCyZBC/gHuBMizR7wO9sXH74kZmf0ZbA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-2.0.0.tgz",
+      "integrity": "sha512-rXcjRgv2MRhpwGHErxKcDcp5IoA9CPvPFLXmmseQYIuQ2fSVu8tsMKi/eYUXzp/HH1s6y3IID/GwRqlSglDdRA==",
       "requires": {
+        "globalthis": "^1.0.0",
         "observable-webworkers": "^1.0.0",
         "p-queue": "^6.0.0",
         "promise-timeout": "^1.3.0",
@@ -5644,48 +5933,33 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multiaddr": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-6.1.1.tgz",
-      "integrity": "sha512-Q1Ika0F9MNhMtCs62Ue+GWIJtRFEhZ3Xz8wH7/MZDVZTWhil1/H2bEGN02kUees3hkI3q1oHSjmXYDM0gxaFjQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-8.0.0.tgz",
+      "integrity": "sha512-4OOyr0u0i4lvh9MY/mvuCNmH5eqoTamcnGeXz6umFGc0eaVQUGPDQNbp52YfFY92NlZ76pO6h4K2HkXsT5X43w==",
       "requires": {
-        "bs58": "^4.0.1",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "hi-base32": "~0.5.0",
-        "ip": "^1.1.5",
-        "is-ip": "^2.0.0",
+        "is-ip": "^3.1.0",
+        "multibase": "^3.0.0",
+        "uint8arrays": "^1.1.0",
         "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
-        },
-        "is-ip": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-          "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
-          "requires": {
-            "ip-regex": "^2.0.0"
-          }
-        }
       }
     },
     "multiaddr-to-uri": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-4.0.1.tgz",
-      "integrity": "sha512-RVHKm5NXcMWMIhrwF4B4Q34JtMXt1/2wgnDTnKRE+AGAiXfqFika0bIfCsAtLp+gZJOWeDLeT1vR6P0gGyVAtg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-6.0.0.tgz",
+      "integrity": "sha512-OjpkVHOXEmIKMO8WChzzQ7aZQcSQX8squxmvtDbRpy7/QNmJ3Z7jv6qyD74C28QtaeNie8O8ngW2AkeiMmKP7A==",
       "requires": {
-        "multiaddr": "^6.0.3"
+        "multiaddr": "^8.0.0"
       }
     },
     "multibase": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-      "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+      "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
       "requires": {
         "base-x": "^3.0.8",
-        "buffer": "^5.5.0"
+        "web-encoding": "^1.0.2"
       }
     },
     "multicast-dns": {
@@ -5698,21 +5972,44 @@
       }
     },
     "multicodec": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
-      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-2.0.1.tgz",
+      "integrity": "sha512-YDYeWn9iGa76hOHAyyZa0kbt3tr5FLg1ZXUHrZUJltjnxxdbTIbHnxWLd2zTcMOjdT3QyO+Xs4bQgJUcC2RWUA==",
       "requires": {
+        "uint8arrays": "1.0.0",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "uint8arrays": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.0.0.tgz",
+          "integrity": "sha512-14tqEVujDREW7YwonSZZwLvo7aFDfX7b6ubvM/U7XvZol+CC/LbhaX/550VlWmhddAL9Wou1sxp0Of3tGqXigg==",
+          "requires": {
+            "multibase": "^3.0.0",
+            "web-encoding": "^1.0.2"
+          }
+        }
       }
     },
     "multihashes": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
-      "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+      "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
       "requires": {
-        "buffer": "^5.5.0",
-        "multibase": "^0.7.0",
+        "multibase": "^3.0.0",
+        "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
+      }
+    },
+    "multihashing": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.3.3.tgz",
+      "integrity": "sha512-jXVWf5uqnZUhc1mLFPWOssuOpkj/A/vVLKrtEscD1PzSLobXYocBy9Gqa/Aw4229/heGnl0RBHU3cD53MbHUig==",
+      "requires": {
+        "blakejs": "^1.1.0",
+        "js-sha3": "~0.8.0",
+        "multihashes": "~0.4.14",
+        "webcrypto": "~0.1.1"
       },
       "dependencies": {
         "multibase": {
@@ -5723,36 +6020,46 @@
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
           }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
     "multihashing-async": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.6.0.tgz",
-      "integrity": "sha512-Qv8pgg99Lewc191A5nlXy0bSd2amfqlafNJZmarU6Sj7MZVjpR94SCxQjf4DwPtgWZkiLqsjUQBXA2RSq+hYyA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.0.1.tgz",
+      "integrity": "sha512-LZcH8PqW4iEKymaJ3RpsgpSJhXF29kAvO02ccqbysiXkQhZpVce8rrg+vzRKWO89hhyIBnQHI2e/ZoRVxmiJ2Q==",
       "requires": {
         "blakejs": "^1.1.0",
-        "js-sha3": "~0.8.0",
-        "multihashes": "~0.4.13",
-        "murmurhash3js": "^3.0.1",
-        "nodeify": "^1.0.1"
+        "err-code": "^2.0.0",
+        "js-sha3": "^0.8.0",
+        "multihashes": "^3.0.1",
+        "murmurhash3js-revisited": "^3.0.0",
+        "uint8arrays": "^1.0.0"
       }
     },
     "multistream-select": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.14.6.tgz",
-      "integrity": "sha512-oRxaStv2thLDZi3eojRgolS9DHbH5WENV2NwN6VwubEwsuwSEALbmSyxQ7PSzB7rSjgX2LGpuMzZ9O+ZptbEyA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-1.0.0.tgz",
+      "integrity": "sha512-82riQ+qZ0RPY+KbRdeeKKQnFSBCVpUbZ15EniGU2nfwM8NdrpPIeUYXFw4a/pyprcNeRfMgLlG9aCh874p8nJg==",
       "requires": {
-        "async": "^2.6.3",
+        "bl": "^4.0.0",
         "debug": "^4.1.1",
-        "err-code": "^1.1.2",
-        "interface-connection": "~0.3.3",
-        "once": "^1.4.0",
-        "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.3",
-        "pull-stream": "^3.6.13",
-        "semver": "^6.2.0",
-        "varint": "^5.0.0"
+        "err-code": "^2.0.0",
+        "it-handshake": "^1.0.2",
+        "it-length-prefixed": "^3.0.0",
+        "it-pipe": "^1.0.1",
+        "it-reader": "^2.0.0",
+        "p-defer": "^3.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "murmurhash3js": {
@@ -5765,35 +6072,42 @@
       "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
       "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
     },
+    "mutable-proxy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mutable-proxy/-/mutable-proxy-1.0.0.tgz",
+      "integrity": "sha512-4OvNRr1DJpy2QuDUV74m+BWZ//n4gG4bmd21MzDSPqHEidIDWqwyOjcadU1LBMO3vXYGurVKjfBrxrSQIHFu9A=="
+    },
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
     },
     "napi-macros": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
-    "ndjson": {
-      "version": "github:hugomrdias/ndjson#4db16da6b42e5b39bf300c3a7cde62abb3fa3a11",
-      "from": "github:hugomrdias/ndjson#feat/readable-stream3",
-      "requires": {
-        "json-stringify-safe": "^5.0.1",
-        "minimist": "^1.2.0",
-        "split2": "^3.1.0",
-        "through2": "^3.0.0"
-      }
-    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-addon-api": {
       "version": "2.0.2",
@@ -5811,9 +6125,9 @@
       "integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw=="
     },
     "node-gyp-build": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "nodeify": {
       "version": "1.0.1",
@@ -5824,23 +6138,28 @@
         "promise": "~1.3.0"
       }
     },
+    "nofilter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
+      "integrity": "sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA=="
+    },
     "normalize-url": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "^3.0.0"
       }
     },
     "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
     },
     "object-component": {
       "version": "0.0.3",
@@ -5865,6 +6184,14 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
     "opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -5884,48 +6211,114 @@
       "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
       "optional": true
     },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-    },
     "orbit-db": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/orbit-db/-/orbit-db-0.21.5.tgz",
-      "integrity": "sha512-DrEQfpisxS4v4bZnJw4bVelKftxYqyET8fVXTtD9iGWKuMUQjKQeYbtQSrwMaAqGPLXQsLdX1vAvo0/1LtaiLg==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/orbit-db/-/orbit-db-0.25.3.tgz",
+      "integrity": "sha512-8DTGZmanXYhcRh7JT2o7tje+Jgp3a6RZSnc3Uvmn+bvnMH2U0xBv6y2WQDC0nlFxP1nIZKR6ULVbgvhSS9ucww==",
       "requires": {
-        "cids": "^0.7.1",
-        "ipfs-pubsub-1on1": "~0.0.4",
+        "cids": "^1.0.0",
+        "ipfs-pubsub-1on1": "~0.0.6",
+        "is-node": "^1.0.2",
         "localstorage-down": "^0.6.7",
         "logplease": "^1.2.14",
-        "multihashes": "^0.4.12",
-        "orbit-db-access-controllers": "~0.2.0",
-        "orbit-db-cache": "~0.2.4",
-        "orbit-db-counterstore": "~1.5.0",
-        "orbit-db-docstore": "~1.5.0",
-        "orbit-db-eventstore": "~1.5.0",
-        "orbit-db-feedstore": "~1.5.0",
-        "orbit-db-identity-provider": "~0.1.0",
-        "orbit-db-io": "~0.1.0",
-        "orbit-db-keystore": "^0.2.1",
-        "orbit-db-kvstore": "~1.5.0",
+        "multihashes": "~3.0.1",
+        "orbit-db-access-controllers": "^0.2.2",
+        "orbit-db-cache": "~0.3.0",
+        "orbit-db-counterstore": "~1.11.0",
+        "orbit-db-docstore": "~1.11.0",
+        "orbit-db-eventstore": "~1.11.0",
+        "orbit-db-feedstore": "~1.11.0",
+        "orbit-db-identity-provider": "~0.3.0",
+        "orbit-db-io": "~0.2.0",
+        "orbit-db-keystore": "~0.3.0",
+        "orbit-db-kvstore": "~1.11.0",
         "orbit-db-pubsub": "~0.5.5",
-        "orbit-db-store": "~2.6.0"
+        "orbit-db-storage-adapter": "~0.5.3",
+        "orbit-db-store": "~3.5.0"
       }
     },
     "orbit-db-access-controllers": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/orbit-db-access-controllers/-/orbit-db-access-controllers-0.2.5.tgz",
-      "integrity": "sha512-wMwRv3MquukJPkAsuybbsn6rwXOol92fE+fIcA4QYTIpGQZWgCes2IIrilHGEFUNLxpkocRqWTy1GfPl//Zosw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/orbit-db-access-controllers/-/orbit-db-access-controllers-0.2.6.tgz",
+      "integrity": "sha512-A/gi/ROEM1BDM44z5XeU80+gS6Q1uSc3jTOf6N1ripw//iQYTaTFihCcLPBGSnD2uDVXWU0wql3wSUD0k7JQ5Q==",
       "requires": {
         "orbit-db-io": "^0.2.0",
-        "p-map-series": "^1.0.0"
+        "p-map-series": "^2.1.0"
+      }
+    },
+    "orbit-db-cache": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.3.0.tgz",
+      "integrity": "sha512-jUsS+D3jXCwvFy92rqvsEroBMRD1SVyBwRJO248F/0/xIJ7zg+DGmhgukivUDvCrx3cpAXqYqh3Ob+kS+K9QBA==",
+      "requires": {
+        "logplease": "~1.2.15"
+      }
+    },
+    "orbit-db-counterstore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-counterstore/-/orbit-db-counterstore-1.11.0.tgz",
+      "integrity": "sha512-CnHWU4/JfxLDfZ9LMW66AhF8GWnyCW/wiD5uDPls51zk0iI+FhMrxLHZgSFdlkIvfakZiufnRqly6rWSfh1hMg==",
+      "requires": {
+        "crdts": "~0.1.2"
+      }
+    },
+    "orbit-db-docstore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.11.0.tgz",
+      "integrity": "sha512-3RjR1sA1hcDWL+paYwYDsVqEMWljVTykDq7ExwHUlvxWnSscwIXSJe71E2cX8CFSipzraiPl4flPkVFEYyPbsA==",
+      "requires": {
+        "p-map": "~1.1.1"
       },
       "dependencies": {
-        "err-code": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+        "p-map": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
+          "integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
+        }
+      }
+    },
+    "orbit-db-eventstore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-eventstore/-/orbit-db-eventstore-1.11.0.tgz",
+      "integrity": "sha512-fXDlvJg3SJSosf/V9LcPO+UVnx5hlMWf8jO5UijglZzXE5QYkCsCF6MQTuj3rTffvgBW8XdpHhun6/b68g+n2g=="
+    },
+    "orbit-db-feedstore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-feedstore/-/orbit-db-feedstore-1.11.0.tgz",
+      "integrity": "sha512-UpRe8fBt6PsnlxEKB+CWG1MDYzwIyYpGchqiob4PvpBGQ/vdg4Bymm4WBYwG1Gl6v2TFuVJSYnR+qXYAHf3nvg==",
+      "requires": {
+        "orbit-db-eventstore": "~1.11.0"
+      }
+    },
+    "orbit-db-identity-provider": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/orbit-db-identity-provider/-/orbit-db-identity-provider-0.3.1.tgz",
+      "integrity": "sha512-kR6uUCovNecTTPTDsCkm07VEEg1nozx5bz0/ZUO7Oo+0EhCACPO9DZ3g5Wy9bPBHyaaRYqcocQfqAvTdfwyWLQ==",
+      "requires": {
+        "ethers": "^5.0.8",
+        "orbit-db-keystore": "~0.3.5"
+      }
+    },
+    "orbit-db-io": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.2.0.tgz",
+      "integrity": "sha512-wOunD4ZRgtTsAXJEu9NNEeJ8s98tZTtFlrLiI/ThuDKBy4AwpIvr+vMkzMD0DMSUTurRtK+xz7AfkP0nd9bcxQ==",
+      "requires": {
+        "cids": "^0.7.1",
+        "ipld-dag-pb": "^0.18.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
+          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "^1.0.0",
+            "multihashes": "~0.4.15"
+          }
         },
         "ipld-dag-pb": {
           "version": "0.18.5",
@@ -5952,13 +6345,32 @@
                 "multicodec": "^1.0.1",
                 "multihashes": "^1.0.1"
               }
+            },
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
             }
           }
         },
         "multibase": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
+          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
@@ -5974,13 +6386,24 @@
           }
         },
         "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
           "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
             "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+              "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
           }
         },
         "multihashing-async": {
@@ -5994,163 +6417,58 @@
             "js-sha3": "^0.8.0",
             "multihashes": "^1.0.1",
             "murmurhash3js-revisited": "^3.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
           }
         },
-        "orbit-db-io": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.2.0.tgz",
-          "integrity": "sha512-wOunD4ZRgtTsAXJEu9NNEeJ8s98tZTtFlrLiI/ThuDKBy4AwpIvr+vMkzMD0DMSUTurRtK+xz7AfkP0nd9bcxQ==",
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
           "requires": {
-            "cids": "^0.7.1",
-            "ipld-dag-pb": "^0.18.1"
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
           }
         }
-      }
-    },
-    "orbit-db-cache": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/orbit-db-cache/-/orbit-db-cache-0.2.5.tgz",
-      "integrity": "sha512-e6/jsBk02AMwi4+c02mt5W7oI/GUMdpZhRORcOrnq4QWs5gbP1PkiXcji9IhWakXpMUfuqodldj1nqrBQjPF3Q==",
-      "requires": {
-        "level-js": "~4.0.1",
-        "leveldown": "~5.0.3",
-        "logplease": "~1.2.15",
-        "mkdirp": "^0.5.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
-          "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
-          "requires": {
-            "level-concat-iterator": "~2.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
-        "immediate": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-        },
-        "level-js": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.2.tgz",
-          "integrity": "sha512-PeGjZsyMG4O89KHiez1zoMJxStnkM+oBIqgACjoo5PJqFiSUUm3GNod/KcbqN5ktyZa8jkG7I1T0P2u6HN9lIg==",
-          "requires": {
-            "abstract-leveldown": "~6.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "^2.0.3",
-            "ltgt": "^2.1.2",
-            "typedarray-to-buffer": "~3.1.5"
-          }
-        },
-        "leveldown": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.0.3.tgz",
-          "integrity": "sha512-isfWtOQIXbGbQRI8nmU9FqCZM0klmqTAOFi0vF6G/D0O1ZgxLrSh6Xd4Zj9iVQfGt6+8jpYwkRbN07VLrxRM8w==",
-          "requires": {
-            "abstract-leveldown": "~6.0.3",
-            "fast-future": "~1.0.2",
-            "napi-macros": "~1.8.1",
-            "node-gyp-build": "~3.8.0"
-          }
-        },
-        "napi-macros": {
-          "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
-          "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg=="
-        },
-        "node-gyp-build": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
-          "integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw=="
-        }
-      }
-    },
-    "orbit-db-counterstore": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/orbit-db-counterstore/-/orbit-db-counterstore-1.5.2.tgz",
-      "integrity": "sha512-TlzifqqsBk6sA5SsDpXVhsq4TC8YUQ/Pr9+osUxxKcfR17X1oEWGUgpRUNhT9LnZklPe9orvuEb0gk+Y3EsNdw==",
-      "requires": {
-        "crdts": "~0.1.2",
-        "orbit-db-store": "~2.6.0"
-      }
-    },
-    "orbit-db-docstore": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-docstore/-/orbit-db-docstore-1.5.1.tgz",
-      "integrity": "sha512-HzV93dJ6r5K0+elEXam31ZWxz2z6Gvil8jwCM27wceZbqrnjibzkCavIflknsosgA49o0y7ZbL6F1Z9JwI7PCQ==",
-      "requires": {
-        "orbit-db-store": "~2.6.0",
-        "p-map": "~1.1.1"
-      },
-      "dependencies": {
-        "p-map": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.1.1.tgz",
-          "integrity": "sha1-BfXkrpegaDcbwqXMhr+9vBnErno="
-        }
-      }
-    },
-    "orbit-db-eventstore": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-eventstore/-/orbit-db-eventstore-1.5.1.tgz",
-      "integrity": "sha512-ZPRe9jXaf7P5QcJWEJKOZi5WRDt4K62pbTk1wdoQPvZ9xJiB/dUaA7M0Twq4qosv2SfbKVCClUbTzqzreLqIeA==",
-      "requires": {
-        "orbit-db-store": "~2.6.0"
-      }
-    },
-    "orbit-db-feedstore": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-feedstore/-/orbit-db-feedstore-1.5.1.tgz",
-      "integrity": "sha512-o9XYcrhb0+Cx+QgF4W9gynYUTDFLvJA/r94VJM9O1g53Aw9pA/106TGlX/1bo7oUpFFlIjDIWfawRPSWgw9yqw==",
-      "requires": {
-        "orbit-db-eventstore": "~1.5.0"
-      }
-    },
-    "orbit-db-identity-provider": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/orbit-db-identity-provider/-/orbit-db-identity-provider-0.1.7.tgz",
-      "integrity": "sha512-4V/RyLN3uXxzfYBhizcIy2NQmeOXpxx6l65PkExFs2reeULHgxuenbbTLxBOvP0nOnEE9L4U6JjNrJkbpyO20A==",
-      "requires": {
-        "ethers": "^4.0.20",
-        "orbit-db-keystore": "~0.2.0"
-      }
-    },
-    "orbit-db-io": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-io/-/orbit-db-io-0.1.1.tgz",
-      "integrity": "sha512-akXMNe6Zjj4XOOO3fW08jvNFL7ttn4pyaKhsooNVt1TNhi2f9cdsumz9NJskl2/go2U4IJcnXRPQGqIBdVulFw==",
-      "requires": {
-        "cids": "^0.7.1",
-        "ipld-dag-pb": "^0.17.4"
       }
     },
     "orbit-db-keystore": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.2.4.tgz",
-      "integrity": "sha512-Uw6CDPu7xwB5MS7P0QurwIDsmz1V8SC+OEXzudAbJYTb0kXRomFpsvm1I7VCHgFe59laDIe4z5XXJ6iKEUn31g==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/orbit-db-keystore/-/orbit-db-keystore-0.3.5.tgz",
+      "integrity": "sha512-oyu8BndnGnX+7tEHfkXBxiSPMSeztLweIUUY4OwyKysXaqd5CWvNDGT3tVZ4jq8dJ13LNmfQzdr20PjIRcBVig==",
       "requires": {
-        "elliptic": "^6.4.1",
-        "level-js": "~4.0.1",
+        "elliptic": "^6.5.3",
+        "level": "~5.0.1",
         "leveldown": "~5.1.1",
         "levelup": "~4.1.0",
         "libp2p-crypto": "^0.16.0",
         "libp2p-crypto-secp256k1": "^0.3.0",
         "lru": "^3.1.0",
-        "mkdirp": "^0.5.1",
-        "safe-buffer": "^5.1.2"
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1"
       },
       "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
-          "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
-          "requires": {
-            "level-concat-iterator": "~2.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
         "deferred-leveldown": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.1.0.tgz",
@@ -6158,23 +6476,6 @@
           "requires": {
             "abstract-leveldown": "~6.0.0",
             "inherits": "^2.0.3"
-          }
-        },
-        "immediate": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-        },
-        "level-js": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.2.tgz",
-          "integrity": "sha512-PeGjZsyMG4O89KHiez1zoMJxStnkM+oBIqgACjoo5PJqFiSUUm3GNod/KcbqN5ktyZa8jkG7I1T0P2u6HN9lIg==",
-          "requires": {
-            "abstract-leveldown": "~6.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "^2.0.3",
-            "ltgt": "^2.1.2",
-            "typedarray-to-buffer": "~3.1.5"
           }
         },
         "leveldown": {
@@ -6198,20 +6499,95 @@
             "xtend": "~4.0.0"
           }
         },
+        "libp2p-crypto": {
+          "version": "0.16.3",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.16.3.tgz",
+          "integrity": "sha512-ro7/5Tu+f8p2+qDS1JrROnO++nNaAaBFs+VVXVHLuTMnbnMASu1eUtSlWPk1uOwikAlBFTvfqe5J1bK6Bpq6Pg==",
+          "requires": {
+            "asmcrypto.js": "^2.3.2",
+            "asn1.js": "^5.0.1",
+            "async": "^2.6.1",
+            "bn.js": "^4.11.8",
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.3.0",
+            "multihashing-async": "~0.5.1",
+            "node-forge": "~0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "ursa-optional": "~0.10.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.21",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.21.tgz",
+          "integrity": "sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.2.tgz",
+          "integrity": "sha512-mmyG6M/FKxrpBh9xQDUvuJ7BbqT93ZeEeH5X6LeMYKoYshYLr9BDdCsvDtZvn+Egf+/Xi+aOznrWL4vp3s+p0Q==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "js-sha3": "~0.8.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
         "napi-macros": {
           "version": "1.8.2",
           "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
           "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg=="
+        },
+        "node-gyp-build": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+          "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
     "orbit-db-kvstore": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/orbit-db-kvstore/-/orbit-db-kvstore-1.5.1.tgz",
-      "integrity": "sha512-fCov8iLmUA0GIsZi6oRspsAy3Rh5yaTBTnuJ/gN6MPU0LWuhZwH3sq/WVsrEQI8uGU4or4SKypSFSp8PC/G3qA==",
-      "requires": {
-        "orbit-db-store": "~2.6.0"
-      }
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-kvstore/-/orbit-db-kvstore-1.11.0.tgz",
+      "integrity": "sha512-IIsEwFqXJfFoGp1j3KvhANq5QRCHnnfE3R45QLrL1eiwGYRvXQwrIIEw6HzDgynj+Ae/2brnvav/3isM4pzjnQ=="
     },
     "orbit-db-pubsub": {
       "version": "0.5.7",
@@ -6223,67 +6599,91 @@
         "p-series": "^1.1.0"
       }
     },
-    "orbit-db-store": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/orbit-db-store/-/orbit-db-store-2.6.6.tgz",
-      "integrity": "sha512-t5i0lHCPuUDN3wXWVjRnB1OK3BeRr4MsjlOwsa5i7PRzkFlWpoWsoYCrbPpavW0oaynqOsJ8F6dpIJYFbfDVZA==",
+    "orbit-db-storage-adapter": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/orbit-db-storage-adapter/-/orbit-db-storage-adapter-0.5.3.tgz",
+      "integrity": "sha512-K/YDVcKkhzEnqK1WFtjcADTtNZdskBJyaTCUY+m0dCuf39VHsXO4kRq5htpT1wJ6yI9dlG6TysVh+duA3o+Xig==",
       "requires": {
-        "ipfs-log": "~4.3.2",
-        "logplease": "^1.2.14",
-        "orbit-db-io": "~0.1.0",
-        "p-each-series": "^1.0.0",
-        "p-map": "^3.0.0",
-        "readable-stream": "~2.3.5"
+        "level": "^5.0.1",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
+            "minimist": "^1.2.5"
           }
         }
       }
     },
+    "orbit-db-store": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/orbit-db-store/-/orbit-db-store-3.5.0.tgz",
+      "integrity": "sha512-y17PSbZwKCIax2zNHXRVcMQzOd/rCXx1Oei9gX/XHW9+nlqBKx96BWVnkw01TAWtf1GJlj0sJwvxAkWlWVcM5A==",
+      "requires": {
+        "ipfs-log": "~4.6.4",
+        "it-to-stream": "^0.1.2",
+        "logplease": "^1.2.14",
+        "orbit-db-io": "~0.2.0",
+        "p-each-series": "^2.1.0",
+        "p-map": "^4.0.0",
+        "p-queue": "^6.6.1",
+        "readable-stream": "~3.6.0"
+      }
+    },
+    "p-any": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-any/-/p-any-3.0.0.tgz",
+      "integrity": "sha512-5rqbqfsRWNb0sukt0awwgJMlaep+8jV45S15SKKB34z4UuzjcofIfnriCBhWjZP2jbVtjt9yRl7buB6RlKsu9w==",
+      "requires": {
+        "p-cancelable": "^2.0.0",
+        "p-some": "^5.0.0"
+      }
+    },
     "p-cancelable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
+    },
+    "p-defer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+      "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+    },
+    "p-do-whilst": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+      "resolved": "https://registry.npmjs.org/p-do-whilst/-/p-do-whilst-1.1.0.tgz",
+      "integrity": "sha512-ntAQbyZJAqCBoTrW3M8XEn1+45wkWgoG6EKRKGCrSvMs0wBY2a3W3mY0I5OErEweFrQsTLAhIv3KN6yyujQnzQ=="
     },
     "p-each-series": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+      "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ=="
+    },
+    "p-fifo": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
-      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+      "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
       "requires": {
-        "p-reduce": "^1.0.0"
+        "fast-fifo": "^1.0.0",
+        "p-defer": "^3.0.0"
+      }
+    },
+    "p-filter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "requires": {
+        "p-map": "^2.0.0"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+        }
       }
     },
     "p-finally": {
@@ -6292,9 +6692,9 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-forever": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-1.0.1.tgz",
-      "integrity": "sha512-9IVAxJdPk88BFMvPjzE+WTZLmAt/FBa47mYY49E2elBki4yJJmQ57XHu3o3Dm1GMde+Xf2d+PzElJIogAPwkug=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-forever/-/p-forever-2.1.0.tgz",
+      "integrity": "sha512-kqZrNBsD8fUPCpZLYJoHTiONQVrdkA2nKwSsTfIr5h7P8jGpSy+Vzkxu6nVcZcz3c/rSx/Ys3AACd/BkMKvqbw=="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -6305,25 +6705,25 @@
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^2.2.0"
       }
     },
     "p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
     },
     "p-map-series": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-1.0.0.tgz",
-      "integrity": "sha1-v5j+V1cFZYqeE1G++4WuTB8Hvco=",
-      "requires": {
-        "p-reduce": "^1.0.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map-series/-/p-map-series-2.1.0.tgz",
+      "integrity": "sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q=="
     },
     "p-queue": {
       "version": "6.6.1",
@@ -6338,6 +6738,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
+    },
+    "p-reflect": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
+      "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg=="
     },
     "p-series": {
       "version": "1.1.0",
@@ -6355,6 +6760,24 @@
         }
       }
     },
+    "p-settle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
+      "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
+      "requires": {
+        "p-limit": "^2.2.2",
+        "p-reflect": "^2.1.0"
+      }
+    },
+    "p-some": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-some/-/p-some-5.0.0.tgz",
+      "integrity": "sha512-Js5XZxo6vHjB9NOYAzWDYAIyyiPvva0DWESAIWIK7uhSpGsyg5FwUPxipU/SOQx5x9EqhOh545d1jo6cVkitig==",
+      "requires": {
+        "aggregate-error": "^3.0.0",
+        "p-cancelable": "^2.0.0"
+      }
+    },
     "p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -6364,11 +6787,11 @@
       }
     },
     "p-times": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-times/-/p-times-2.1.0.tgz",
-      "integrity": "sha512-y23lF7HegeUyBTAxHNl6qYvwTy6S4d+BQcs+4CwgxXzc1v1Hsf7pyAqbDHMiYnjdL5Vcmr/oHc9l+nAu0Q+Hhg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-times/-/p-times-3.0.0.tgz",
+      "integrity": "sha512-/Z7mcs8Liie8E7IHI9SBtmkHVW/GjLroQ94ALoAMIG20mqFMuh56/3WYhtOTqX9ccRSOxgaCkFC94Bat1Ofskg==",
       "requires": {
-        "p-map": "^2.0.0"
+        "p-map": "^4.0.0"
       }
     },
     "p-try": {
@@ -6376,10 +6799,23 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "p-try-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/p-try-each/-/p-try-each-1.0.1.tgz",
+      "integrity": "sha512-WyUjRAvK4CG9DUW21ZsNYcBj6guN7pgZAOFR8mUtyNXyPC5WUo3L48nxI5TsGEZ+VJhZXzyeH/Sxi2lxYcPp3A=="
+    },
+    "p-wait-for": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
+      "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
+      "requires": {
+        "p-timeout": "^3.0.0"
+      }
+    },
     "p-whilst": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-whilst/-/p-whilst-1.0.0.tgz",
-      "integrity": "sha1-VGaOrX+TR5n8APHlIw/Wrd645+Y="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-whilst/-/p-whilst-2.1.0.tgz",
+      "integrity": "sha512-uzp1HPgqzokEmZN+VpfQ9PO4YY5xm+jpLJeL9FN1NPU4d4IZh8eEV+mtQXd+/22R1P7C5j19b7Y//oUc7k0+RQ=="
     },
     "package-json": {
       "version": "6.5.0",
@@ -6390,7 +6826,36 @@
         "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
         "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
+    },
+    "parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+      "requires": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-duration": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
+      "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg=="
+    },
+    "parse-headers": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA=="
     },
     "parseqs": {
       "version": "0.0.5",
@@ -6409,24 +6874,32 @@
       }
     },
     "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-    },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -6440,36 +6913,23 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peer-book": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.9.2.tgz",
-      "integrity": "sha512-AW7DrC7HVe3jKYTKRvceX6poLiNOg6K9dW5aJejpxK849KuhI1H6nzefEx6v5GLAnXLA7bOoJjGx/ke+MCJ3vQ==",
-      "requires": {
-        "bs58": "^4.0.1",
-        "peer-id": "~0.12.2",
-        "peer-info": "~0.15.1"
-      }
+    "peek-readable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
+      "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
     },
     "peer-id": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.12.5.tgz",
-      "integrity": "sha512-3xVWrtIvNm9/OPzaQBgXDrfWNx63AftgFQkvqO6YSZy7sP3Fuadwwbn54F/VO9AnpyW/26i0WRQz9FScivXrmw==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.14.1.tgz",
+      "integrity": "sha512-QSEyJy9fEOtgB/NVrlJvlxO1Q8ZKpTLJ/HBVTj7bGJFGnm4febqSB/KlEL4WYm/fgvriHM+Wkfea3yD1Uacllw==",
       "requires": {
-        "async": "^2.6.3",
+        "cids": "^1.0.0",
         "class-is": "^1.1.0",
-        "libp2p-crypto": "~0.16.1",
-        "multihashes": "~0.4.15"
-      }
-    },
-    "peer-info": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.1.tgz",
-      "integrity": "sha512-Y91Q2tZRC0CpSTPd1UebhGqniOrOAk/aj60uYUcWJXCoLTAnGu+4LJGoiay8ayudS6ice7l3SKhgL/cS62QacA==",
-      "requires": {
-        "mafmt": "^6.0.2",
-        "multiaddr": "^6.0.3",
-        "peer-id": "~0.12.2",
-        "unique-by": "^1.0.0"
+        "libp2p-crypto": "^0.18.0",
+        "minimist": "^1.2.5",
+        "multihashes": "^3.0.1",
+        "protons": "^2.0.0",
+        "uint8arrays": "^1.1.0"
       }
     },
     "pem-jwk": {
@@ -6480,40 +6940,35 @@
         "asn1.js": "^5.0.1"
       }
     },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-    },
     "pino": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-      "integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.6.1.tgz",
+      "integrity": "sha512-DOgm7rn6ctBkBYemHXSLj7+j3o3U1q1FWBXbHcprur8mA93QcJSycEkEqhqKiFB9Mx/3Qld2FGr6+9yfQza0kA==",
       "requires": {
         "fast-redact": "^2.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
         "pino-std-serializers": "^2.4.2",
-        "quick-format-unescaped": "^3.0.3",
-        "sonic-boom": "^0.7.5"
+        "quick-format-unescaped": "^4.0.1",
+        "sonic-boom": "^1.0.2"
       }
     },
     "pino-pretty": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-3.6.1.tgz",
-      "integrity": "sha512-S3bal+Yd313OEaPijbf7V+jPxVaTaRO5RQX8S/Mwdtb/8+JOgo1KolDeJTfMDTU2/k6+MHvEbxv+T1ZRfGlnjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.2.1.tgz",
+      "integrity": "sha512-WyO/n6c6T2gj0ioYGFUFbrvyUoERK37Lu0liLxMIJnp1YaaG+XZBU2TAQB0yVJNb+7T+oDh9t8HGMzk00jy+tw==",
       "requires": {
-        "@hapi/bourne": "^1.3.2",
+        "@hapi/bourne": "^2.0.0",
         "args": "^5.0.1",
-        "chalk": "^2.4.2",
+        "chalk": "^4.0.0",
         "dateformat": "^3.0.3",
         "fast-safe-stringify": "^2.0.7",
         "jmespath": "^0.15.0",
         "joycon": "^2.2.5",
         "pump": "^3.0.0",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.6.0",
         "split2": "^3.1.1",
-        "strip-json-comments": "^3.0.1"
+        "strip-json-comments": "^3.1.1"
       }
     },
     "pino-std-serializers": {
@@ -6526,10 +6981,10 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
-    "priorityqueue": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/priorityqueue/-/priorityqueue-0.2.1.tgz",
-      "integrity": "sha512-Dr6ZkRFGZHoAri6iNp5KvspOrFPfhxJ5AExXqLy5ChgdwALd3nC+q5/QG+gmjmf9W63joDXc+Zp0h05Ug/RtYg=="
+    "pretty-bytes": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -6542,10 +6997,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "prom-client": {
-      "version": "11.5.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
-      "optional": true,
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+      "integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
       "requires": {
         "tdigest": "^0.1.1"
       }
@@ -6582,11 +7036,6 @@
         "set-immediate-shim": "^1.0.1"
       }
     },
-    "promisify-es6": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/promisify-es6/-/promisify-es6-1.0.3.tgz",
-      "integrity": "sha512-N9iVG+CGJsI4b4ZGazjwLnxErD2d9Pe4DPvvXSxYA9tFNu8ymXME4Qs5HIQ0LMJpNM7zj+m0NlNnNeqFpKzqnA=="
-    },
     "proper-lockfile": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.1.tgz",
@@ -6597,19 +7046,46 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "protobufjs": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": "^13.7.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.21",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.21.tgz",
+          "integrity": "sha512-tlFWakSzBITITJSxHV4hg4KvrhR/7h3xbJdSFbYJBVzKubrASbnnIFuSgolUh7qKGo/ZeJPKUfbZ0WS6Jp14DQ=="
+        }
+      }
+    },
     "protocol-buffers-schema": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
       "integrity": "sha512-G/2kcamPF2S49W5yaMGdIpkG6+5wZF0fzBteLKgEHjbNzqjZQ85aAs1iJGto31EJaSTkNvHs5IXuHSaTLWBAiA=="
     },
     "protons": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
-      "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-2.0.0.tgz",
+      "integrity": "sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==",
       "requires": {
-        "buffer": "^5.5.0",
         "protocol-buffers-schema": "^3.3.1",
         "signed-varint": "^2.0.1",
+        "uint8arrays": "^1.0.0",
         "varint": "^5.0.0"
       }
     },
@@ -6618,197 +7094,17 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "pull-abortable": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
-      "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
-    },
-    "pull-cat": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
-    },
-    "pull-defer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
-    },
-    "pull-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
-      "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "requires": {
-        "pull-utf8-decoder": "^1.0.2"
-      }
-    },
-    "pull-handshake": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-      "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-pair": "~1.1.0",
-        "pull-pushable": "^2.0.0",
-        "pull-reader": "^1.2.3"
-      }
-    },
-    "pull-length-prefixed": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.3.tgz",
-      "integrity": "sha512-tAvRbeHMrA3pqZVth8A0VAYeTG9+mpBpyzFPTwH65Jf6K5GYB3WFkvLSP/rgXFy+tJ+vqf6tol7gme13r0Z10g==",
-      "requires": {
-        "pull-pushable": "^2.2.0",
-        "pull-reader": "^1.3.1",
-        "safe-buffer": "^5.1.2",
-        "varint": "^5.0.0"
-      }
-    },
-    "pull-many": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.9.tgz",
-      "integrity": "sha512-+jUydDVlj/HsvtDqxWMSsiRq3B0HVo7RhBV4C0p2nZRS3mFTUEu9SPEBN+B5PMaW8KTnblYhTIaKg7oXgGnj4Q==",
-      "requires": {
-        "pull-stream": "^3.4.5"
-      }
-    },
-    "pull-mplex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/pull-mplex/-/pull-mplex-0.1.2.tgz",
-      "integrity": "sha512-LXqunL03yLDP3qHKvBb2iLwqnpFfL5y7Fpo4hUoxdlmXuB+3RkNUG/CIUBjBDGhUxY5xXmpivdrojXIBJ7Ktzw==",
-      "requires": {
-        "async": "^2.6.1",
-        "buffer-reuse-pool": "^1.0.0",
-        "debug": "^4.1.1",
-        "interface-connection": "~0.3.3",
-        "looper": "^4.0.0",
-        "pull-offset-limit": "^1.1.1",
-        "pull-pair": "^1.1.0",
-        "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.9",
-        "pull-through": "^1.0.18",
-        "varint": "^5.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-        }
-      }
-    },
-    "pull-ndjson": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-ndjson/-/pull-ndjson-0.1.1.tgz",
-      "integrity": "sha1-gx4GutmqbFxevBKol+Og4V1J4H4=",
-      "requires": {
-        "pull-split": "^0.2.0",
-        "pull-stream": "^3.4.5",
-        "pull-stringify": "^1.2.2"
-      }
-    },
-    "pull-offset-limit": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pull-offset-limit/-/pull-offset-limit-1.1.1.tgz",
-      "integrity": "sha1-SBk9I3p+KeoT4+/E1I5KPB1saXE=",
-      "requires": {
-        "pull-abortable": "^4.1.0",
-        "pull-stream": "^3.5.0"
-      }
-    },
-    "pull-pair": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
-    },
-    "pull-pushable": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
-      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
-    },
-    "pull-reader": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
-      "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
-    },
-    "pull-sort": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.2.tgz",
-      "integrity": "sha512-jGcAHMP+0Le+bEIhSODlbNNd3jW+S6XrXOlhVzfcKU5HQZjP92OzQSgHHSlwvWRsiTWi+UGgbFpL/5gGgmFoVQ==",
-      "requires": {
-        "pull-defer": "^0.2.3",
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "pull-split": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.1.tgz",
-      "integrity": "sha512-lloBKx+ijuRNvxvhM/SMJQ0r9/0WBGcpCPv8I6MZuYl4D1heUF/eYQObnqVehhtTMYuMwboK7RdhMa4Wg3YB7w==",
-      "requires": {
-        "pull-through": "~1.0.6"
-      }
-    },
-    "pull-stream": {
-      "version": "3.6.14",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.14.tgz",
-      "integrity": "sha512-KIqdvpqHHaTUA2mCYcLG1ibEbu/LCKoJZsBWyv9lSYtPkJPBq8m3Hxa103xHi6D2thj5YXa0TqK3L3GUkwgnew=="
-    },
-    "pull-stream-to-async-iterator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-async-iterator/-/pull-stream-to-async-iterator-1.0.2.tgz",
-      "integrity": "sha512-c3KRs2EneuxP7b6pG9fvQTIjatf33RbIErhbQ75s5r2MI6E8R74NZC1nJgXc8kcmqiQxmr+TWY+WwK2mWaUnlA==",
-      "requires": {
-        "pull-stream": "^3.6.9"
-      }
-    },
-    "pull-stream-to-stream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
-      "integrity": "sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k="
-    },
-    "pull-stringify": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pull-stringify/-/pull-stringify-1.2.2.tgz",
-      "integrity": "sha1-Whw04Adfry8vbUYATjbczTO9fHw="
-    },
-    "pull-through": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-      "requires": {
-        "looper": "~3.0.0"
-      }
-    },
-    "pull-to-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pull-to-stream/-/pull-to-stream-0.1.1.tgz",
-      "integrity": "sha512-thZkMv6F9PILt9zdvpI2gxs19mkDrlixYKX6cOBxAW16i1NZH+yLAmF4r8QfJ69zuQh27e01JZP9y27tsH021w==",
-      "requires": {
-        "readable-stream": "^3.1.1"
-      }
-    },
-    "pull-traverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
-      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
-    },
-    "pull-utf8-decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
-      "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
-    },
-    "pull-ws": {
-      "version": "github:hugomrdias/pull-ws#8e2ce0bb3b1cd6804828316e937fff8e0bef6225",
-      "from": "github:hugomrdias/pull-ws#fix/bundle-size",
-      "requires": {
-        "iso-url": "^0.4.4",
-        "relative-url": "^1.0.2",
-        "safe-buffer": "^5.1.1",
-        "ws": "^1.1.0"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "pump": {
@@ -6820,6 +7116,14 @@
         "once": "^1.3.1"
       }
     },
+    "pupa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
+      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
+    },
     "pushdata-bitcoin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
@@ -6828,79 +7132,27 @@
         "bitcoin-ops": "^1.3.0"
       }
     },
-    "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
-    },
     "queue-microtask": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
       "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA=="
     },
     "quick-format-unescaped": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-      "integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz",
+      "integrity": "sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A=="
     },
     "rabin-wasm": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.0.8.tgz",
-      "integrity": "sha512-TpIki3NG/X7nPnYHtYdF4Vp5NLrHvztiM5oL8+9NoeX/ClUfUyy7Y7DMrESZl1ropCpZJAjFMv/ZHYrkLu3bCQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.1.4.tgz",
+      "integrity": "sha512-y8Rq8lGwUGeAaiQV//3hlyzQHLxg2HTEgZmZ8Mqef5LCH4SOpuUZqHqniCFz60FvF2IWp9mtEz9MRc3RewrJcA==",
       "requires": {
-        "assemblyscript": "github:assemblyscript/assemblyscript#v0.6",
-        "bl": "^1.0.0",
+        "@assemblyscript/loader": "^0.9.2",
+        "bl": "^4.0.1",
         "debug": "^4.1.1",
         "minimist": "^1.2.0",
         "node-fetch": "^2.6.0",
-        "readable-stream": "^2.0.4"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        }
+        "readable-stream": "^3.6.0"
       }
     },
     "randombytes": {
@@ -6908,6 +7160,15 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "requires": {
+        "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
     },
@@ -6939,13 +7200,10 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
+    "readable-web-to-node-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
+      "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
     },
     "registry-auth-token": {
       "version": "4.2.0",
@@ -6977,6 +7235,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "reset": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/reset/-/reset-0.1.0.tgz",
+      "integrity": "sha1-n8cxQXGZWubLC35YsGznUir0uvs="
     },
     "responselike": {
       "version": "1.0.2",
@@ -7028,13 +7291,6 @@
       "requires": {
         "object-assign": "^2.0.0",
         "rsa-unpack": "0.0.6"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-        }
       }
     },
     "rsa-unpack": {
@@ -7043,6 +7299,14 @@
       "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
       "requires": {
         "optimist": "~0.3.5"
+      }
+    },
+    "run": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/run/-/run-1.4.0.tgz",
+      "integrity": "sha1-4X2ekEOrL+F3dsspnhI3848LT/o=",
+      "requires": {
+        "minimatch": "*"
       }
     },
     "safe-buffer": {
@@ -7069,18 +7333,13 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "secp256k1": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "requires": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
         "elliptic": "^6.5.2",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
       }
     },
     "semaphore": {
@@ -7089,22 +7348,22 @@
       "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -7132,35 +7391,18 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "shallow-clone": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-1.0.0.tgz",
-      "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
-      "requires": {
-        "is-extendable": "^0.1.1",
-        "kind-of": "^5.0.0",
-        "mixin-object": "^2.0.1"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shortid": {
       "version": "2.2.15",
@@ -7168,6 +7410,13 @@
       "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
       "requires": {
         "nanoid": "^2.1.0"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "2.1.11",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+        }
       }
     },
     "signal-exit": {
@@ -7183,16 +7432,33 @@
         "varint": "~5.0.0"
       }
     },
-    "simple-peer": {
-      "version": "9.7.2",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.7.2.tgz",
-      "integrity": "sha512-xeMyxa9B4V0eA6mf17fVr8nm2QhAYFu+ZZv8zkSFFTjJETGF227CshwobrIYZuspJglMD63egcevQXGOrTIsuA==",
+    "sinon": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
       "requires": {
-        "debug": "^4.0.1",
-        "get-browser-rtc": "^1.0.0",
-        "queue-microtask": "^1.1.0",
-        "randombytes": "^2.0.3",
-        "readable-stream": "^3.4.0"
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.1.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "smart-buffer": {
@@ -7288,70 +7554,27 @@
         }
       }
     },
-    "socket.io-pull-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/socket.io-pull-stream/-/socket.io-pull-stream-0.1.5.tgz",
-      "integrity": "sha512-lcC2se3iAS33xYGnTDSzYW9P4RPVEgcqACCH7Mawy+2go0Wmx3y72PXGv7KI6Vz1YFcOz7np58FqOnZ/iUCbdg==",
-      "requires": {
-        "data-queue": "0.0.3",
-        "debug": "^3.1.0",
-        "pull-stream": "^3.6.2",
-        "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
     "sonic-boom": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-      "integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.1.0.tgz",
+      "integrity": "sha512-JyOf+Xt7GBN4tAic/DD1Bitw6OMgSHAnswhPeOiLpfRoSjPNjEIi73UF3OxHzhSNn9WavxGuCZzprFCGFSNwog==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"
       }
     },
     "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.0.0.tgz",
+      "integrity": "sha512-hlJLzrn/VN49uyNkZ8+9b+0q9DjmmYcYOnbMQtpkLrYpPwRApDPZfmqbUfJnAA3sb/nRib+nDot7Zi/1ER1fuA==",
       "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "is-plain-obj": "^2.0.0"
       }
     },
     "sparse-array": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
       "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
-    },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "requires": {
-        "through": "2"
-      }
     },
     "split2": {
       "version": "3.2.2",
@@ -7371,27 +7594,18 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
-    "stream-to-blob": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-to-blob/-/stream-to-blob-1.0.2.tgz",
-      "integrity": "sha512-ryeEu3DGMt/095uTShIYGzLbbhZ+tHQtgp5HWEhXALSoc4U1iLSvpReZUdysahnJ3tki80wBBgryqqBzFZ0KaA==",
+    "stream-to-it": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
+      "integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
       "requires": {
-        "once": "^1.3.3"
+        "get-iterator": "^1.0.2"
       }
     },
-    "stream-to-pull-stream": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
-      "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
-      "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
-      }
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    "streaming-iterables": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.2.tgz",
+      "integrity": "sha512-9z5iBWe9WXzdT0X1JT9fVC0mCcVxWt5yzZMBUIgjZnt2k23+UQF8Ac6kiI8DnlYZJn5iysvxKl3uGzlijMQ+/g=="
     },
     "strftime": {
       "version": "0.10.0",
@@ -7399,13 +7613,13 @@
       "integrity": "sha1-s/D6QZKVICpaKJ9ta+n0kJphcZM="
     },
     "string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "requires": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "string_decoder": {
@@ -7417,17 +7631,17 @@
       }
     },
     "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "requires": {
-        "ansi-regex": "^4.1.0"
+        "ansi-regex": "^5.0.0"
       }
     },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -7442,13 +7656,14 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
     },
-    "superstruct": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.6.2.tgz",
-      "integrity": "sha512-lvA97MFAJng3rfjcafT/zGTSWm6Tbpk++DP6It4Qg7oNaeM+2tdJMuVgGje21/bIpBEs6iQql1PJH6dKTjl4Ig==",
+    "strtok3": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
+      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
       "requires": {
-        "clone-deep": "^2.0.1",
-        "kind-of": "^6.0.1"
+        "@tokenizer/token": "^0.1.1",
+        "@types/debug": "^4.1.5",
+        "peek-readable": "^3.1.0"
       }
     },
     "supports-color": {
@@ -7463,30 +7678,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/susie/-/susie-3.0.0.tgz",
       "integrity": "sha512-cjo/RCZdReZeL4DxmXawmblCkmkSVSp+PjxHfYG5zbGrSLxLC6QDMniHeuAN4amtFhNJQ7P+LAyTKl3tvrbSDw=="
-    },
-    "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
     },
     "tdigest": {
       "version": "0.1.1",
@@ -7505,26 +7696,9 @@
       }
     },
     "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "requires": {
-        "execa": "^0.7.0"
-      }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
+      "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw=="
     },
     "thunky": {
       "version": "1.1.0",
@@ -7537,6 +7711,15 @@
       "integrity": "sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=",
       "requires": {
         "lodash.throttle": "^4.1.1"
+      }
+    },
+    "timeout-abort-controller": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
+      "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "retimer": "^2.0.0"
       }
     },
     "timestamp-nano": {
@@ -7576,10 +7759,14 @@
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
     },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    "token-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
+      "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
+      "requires": {
+        "@tokenizer/token": "^0.1.0",
+        "ieee754": "^1.1.13"
+      }
     },
     "truncate-utf8-bytes": {
       "version": "1.0.2",
@@ -7594,10 +7781,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
     "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -7613,131 +7805,83 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
+      "integrity": "sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A=="
     },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-    },
-    "unique-by": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-by/-/unique-by-1.0.0.tgz",
-      "integrity": "sha1-UiDIa6e8Vy+3E610ZRRwy2RCEr0="
-    },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+    "uint8arrays": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+      "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.2"
       }
     },
-    "update-notifier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
-      "integrity": "sha512-grrmrB6Zb8DUiyDIaeRTBCkgISYUgETNe7NglEbVsrLWXeESnlCSP50WfRSj/GmzMPl6Uchj24S/p80nP/ZQrQ==",
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
-        "boxen": "^3.0.0",
-        "chalk": "^2.0.1",
-        "configstore": "^4.0.0",
+        "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+    },
+    "update-notifier": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz",
+      "integrity": "sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==",
+      "requires": {
+        "boxen": "^4.2.0",
+        "chalk": "^3.0.0",
+        "configstore": "^5.0.1",
         "has-yarn": "^2.1.0",
         "import-lazy": "^2.1.0",
         "is-ci": "^2.0.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^3.0.0",
+        "is-installed-globally": "^0.3.1",
+        "is-npm": "^4.0.0",
         "is-yarn-global": "^0.3.0",
         "latest-version": "^5.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "pupa": "^2.0.1",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "uri-to-multiaddr": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-3.0.2.tgz",
-      "integrity": "sha512-I2AO1Y/3hUI7KfHiB6Py64lZ02jAB+hqlMVBzDRn4u6d85x+7tJhRwGzdKEYn8/1kDBtWFZVkHvgepF7Z+C1og==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/uri-to-multiaddr/-/uri-to-multiaddr-4.0.0.tgz",
+      "integrity": "sha512-6zQ1uBlE+F//46CBA3lx3vBMhybSvdGJqgNyQPobSDsWGrDDdmJM/f95GPaswXAGFlRHPqOjrGKT11IcKmIfaA==",
       "requires": {
         "is-ip": "^3.1.0",
-        "multiaddr": "^7.2.1"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
-          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "class-is": "^1.1.0",
-            "multibase": "^1.0.0",
-            "multicodec": "^1.0.1",
-            "multihashes": "^1.0.1"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        },
-        "multiaddr": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
-          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "cids": "~0.8.0",
-            "class-is": "^1.1.0",
-            "is-ip": "^3.1.0",
-            "multibase": "^0.7.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multibase": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
-          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        },
-        "multicodec": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
-          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "varint": "^5.0.0"
-          }
-        },
-        "multihashes": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
-          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
-          "requires": {
-            "buffer": "^5.6.0",
-            "multibase": "^1.0.1",
-            "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
-          }
-        }
+        "multiaddr": "^8.0.0"
       }
     },
     "url-parse-lax": {
@@ -7762,30 +7906,10 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "varint": {
       "version": "5.0.0",
@@ -7793,9 +7917,9 @@
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "varint-decoder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.1.1.tgz",
-      "integrity": "sha1-YT1i8HHX51dqIO/RbvTB4zWg3f0=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-1.0.0.tgz",
+      "integrity": "sha512-JkOvdztASWGUAsXshCFHrB9f6AgR2Q8W08CEyJ+43b1qtFocmI8Sp1R/M0E/hDOY2FzVIqk63tOYLgDYWuJ7IQ==",
       "requires": {
         "varint": "^5.0.0"
       }
@@ -7808,14 +7932,24 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "webrtcsupport": {
-      "version": "github:ipfs/webrtcsupport#0a7099ff04fd36227a32e16966dbb3cca7002378",
-      "from": "github:ipfs/webrtcsupport"
+    "web-encoding": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.4.tgz",
+      "integrity": "sha512-DcXs2lbVPzuJmn2kuDEwul2oZg7p4YMa5J2f0YzsOBHaAnBYGPNUB/rJ74DTjTKpw7F0+lSsVM8sFHE2UyBixg=="
+    },
+    "webcrypto": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.1.tgz",
+      "integrity": "sha512-BAvoatS38TbHdyt42ECLroi27NmDh5iea5l5rHC6nZTZjlbJlndrT0FoIiEq7fmPHpmNtP0lMFKVMEKZQFIrGA==",
+      "requires": {
+        "crypto-browserify": "^3.10.0",
+        "detect-node": "^2.0.3"
+      }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -7826,35 +7960,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "requires": {
-        "string-width": "^2.1.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
+        "string-width": "^4.0.0"
       }
     },
     "wif": {
@@ -7871,13 +7981,13 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "wrappy": {
@@ -7886,33 +7996,25 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
       "requires": {
-        "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-      "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
-      }
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
     },
     "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
@@ -7923,6 +8025,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xor-distance/-/xor-distance-2.0.0.tgz",
       "integrity": "sha512-AsAqZfPAuWx7qB/0kyRDUEvoU3QKsHWzHU9smFlkaiprEpGfJ/NBbLze2Uq0rdkxCxkNM9uOLvz/KoNBCbZiLQ=="
+    },
+    "xsalsa20": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.1.0.tgz",
+      "integrity": "sha512-zd3ytX2cm+tcSndRU+krm0eL4TMMpZE7evs5hLRAoOy6gviqLfe3qOlkjF3i5SeAkQUCeJk0lJZrEU56kHRfWw=="
     },
     "xtend": {
       "version": "4.0.2",
@@ -7940,26 +8047,27 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "yargs-parser": "^18.1.2"
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -7975,70 +8083,12 @@
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
-    "zcash-bitcore-lib": {
-      "version": "0.13.20-rc3",
-      "resolved": "https://registry.npmjs.org/zcash-bitcore-lib/-/zcash-bitcore-lib-0.13.20-rc3.tgz",
-      "integrity": "sha1-gToPVtz4t2vBQplRvqbRI2xQcAg=",
+    "zcash-block": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/zcash-block/-/zcash-block-2.0.0.tgz",
+      "integrity": "sha512-I6pv5b+eGE8CJFmltR+ILHnGcnBO8olV78VicQIaWulMhkomlwDmaMeMshJRLPcnd0FBs58QQVcVNBOT9ojH6Q==",
       "requires": {
-        "bn.js": "=2.0.4",
-        "bs58": "=2.0.0",
-        "buffer-compare": "=1.0.0",
-        "elliptic": "=3.0.3",
-        "inherits": "=2.0.1",
-        "lodash": "=3.10.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz",
-          "integrity": "sha1-Igp81nf38b+pNif/QZN3b+eBlIA="
-        },
-        "bs58": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-2.0.0.tgz",
-          "integrity": "sha1-crcTvtIjoKxRi72g484/SBfznrU="
-        },
-        "buffer-compare": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-compare/-/buffer-compare-1.0.0.tgz",
-          "integrity": "sha1-rKp6lm6Y7un64Usxw5pfFY+zxKI="
-        },
-        "elliptic": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
-          "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
-          "requires": {
-            "bn.js": "^2.0.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "inherits": "^2.0.1"
-          },
-          "dependencies": {
-            "brorand": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz",
-              "integrity": "sha1-B7VMowKGq9Fxig4qgwgD79yb+gQ="
-            },
-            "hash.js": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-              "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-              "requires": {
-                "inherits": "^2.0.1"
-              }
-            }
-          }
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
+        "multihashing": "~0.3.3"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -702,6 +702,11 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -5954,11 +5959,11 @@
       }
     },
     "multibase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
-      "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.1.tgz",
+      "integrity": "sha512-MRU5WpnSg81/vYO977MweoeUAxBdXl7+F5Af2Es+X6Vcgfk/g/EjIqXTgm3kb+xO3m1Kzr+aIV14oRX7nv5Z9w==",
       "requires": {
-        "base-x": "^3.0.8",
+        "@multiformats/base-x": "^4.0.1",
         "web-encoding": "^1.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "docopt": "~0.6.2",
     "hapi": ">17.0.0",
     "http2": "^3.2.0",
-    "ipfs": "^0.36.3",
-    "ipfs-http-client": "^30.0.0",
+    "ipfs": "^0.50.2",
+    "ipfs-http-client": "^47.0.0",
     "js-logger": "^1.6.0",
-    "orbit-db": "^0.21.1",
+    "orbit-db": "^0.25.0",
     "susie": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "url": "https://github.com/orbitdb/orbit-db-http-api.git"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
+    "@hapi/boom": "^9.1.0",
     "docopt": "~0.6.2",
-    "hapi": ">17.0.0",
+    "hapi": "^18.1.0",
     "http2": "^3.2.0",
     "ipfs": "^0.50.2",
     "ipfs-http-client": "^47.0.0",

--- a/src/factory/ipfs-local.js
+++ b/src/factory/ipfs-local.js
@@ -15,20 +15,14 @@ async function api_factory(ipfs_opts, orbitdb_dir, orbitdb_opts, server_opts) {
         config: {
                 Addresses: {
                 Swarm: [
-                '/dnsaddr/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-webrtc-star',
-                '/dnsaddr/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star',
+                  //                  '/dns4/wrtc-star1.par.dwebops.pub/tcp/443/wss/p2p-webrtc-star',
                 ]
             }
         }
     }
     if (orbitdb_dir) orbitdb_opts = Object.assign({'directory': orbitdb_dir}, orbitdb_opts)
     ipfs_opts   = Object.assign(ipfs_defaults, ipfs_opts)
-    ipfs        = await new Promise((resolve, reject) => {
-        var node = new Ipfs(ipfs_opts)
-        node.on("ready", () => {
-          resolve(node)
-        })
-      }).catch((ex) => {throw ex})
+    ipfs        = await Ipfs.create(ipfs_opts)
     orbitdb     = await OrbitDB.createInstance(ipfs, orbitdb_opts)
     dbm         = new DBManager(orbitdb)
     orbitdb_api = new OrbitApi(dbm, server_opts)

--- a/src/lib/orbitdb-api.js
+++ b/src/lib/orbitdb-api.js
@@ -1,5 +1,5 @@
 const Hapi  = require('hapi');
-const Boom  = require('boom');
+const Boom  = require('@hapi/boom');
 const Http2 = require('http2');
 const Susie = require('susie');
 


### PR DESCRIPTION
This PR updates the in-proc js-ipfs to 0.50 among some other deps, fixes `@hapi/boom` and removes the swarm addresses. See the additional comment below.